### PR TITLE
Set remote origin url

### DIFF
--- a/git_toprepo_test.py
+++ b/git_toprepo_test.py
@@ -582,7 +582,9 @@ def test_list_config(tmp_path, capsys, monkeypatch):
     assert (
         "".join(interesting_lines)
         == f"""\
-remote.origin.url=file:///dev/null
+remote.origin.pushurl=file:///dev/null
+remote.origin.url={server_top}
+remote.top.pushurl={server_top}
 toprepo.config.config-branch.path=toprepo.config
 toprepo.config.config-branch.ref=refs/heads/config-branch
 toprepo.config.config-branch.type=git
@@ -593,8 +595,6 @@ toprepo.config.default.type=git
 toprepo.config.default.url=.
 toprepo.missing-commits.rev-test-hash=some-path
 toprepo.missing-commits.rev-test-hash=local-override-path
-toprepo.top.fetchurl={server_top}
-toprepo.top.pushurl={server_top}
 """
     )
 

--- a/git_toprepo_test.py
+++ b/git_toprepo_test.py
@@ -543,11 +543,11 @@ def test_read_config_casing(tmp_path):
 
 
 def test_get_config(tmp_path, capsys):
-    with capsys.disabled():
-        example = GitTopRepoExample(tmp_path)
-        server_top = example.init_server_top()
-        worktree = example.toprepo_init_worktree(server_top)
+    example = GitTopRepoExample(tmp_path)
+    server_top = example.init_server_top()
+    worktree = example.toprepo_init_worktree(server_top)
 
+    capsys.readouterr()  # Reset the stdout capture.
     assert (
         git_toprepo.main(
             ["argv0", "-C", str(worktree.path)]
@@ -560,15 +560,15 @@ def test_get_config(tmp_path, capsys):
 
 
 def test_list_config(tmp_path, capsys, monkeypatch):
-    with capsys.disabled():
-        example = GitTopRepoExample(tmp_path)
-        server_top = example.init_server_top()
-        worktree = example.toprepo_init_worktree(server_top)
+    example = GitTopRepoExample(tmp_path)
+    server_top = example.init_server_top()
+    worktree = example.toprepo_init_worktree(server_top)
 
     envs = os.environ.copy()
     envs["GIT_CONFIG_SYSTEM"] = "/dev/null"
     envs["GIT_CONFIG_GLOBAL"] = "/dev/null"
     monkeypatch.setattr(os, "environ", envs)
+    capsys.readouterr()  # Reset the stdout capture.
     assert (
         git_toprepo.main(["argv0", "-C", str(worktree.path), "config", "--list"]) == 0
     )


### PR DESCRIPTION
`remote.origin.url` is needed by git-submodule to resolve relative URLs. Therefore, set it correctly, set `remote.origin.pushUrl` to /dev/null, to avoid accidental erroneous pushes, and provide a new `remote.top.pushUrl` for power users to use `git push top` directly.

This commit reads and updates the `.git/config` file for backwards compatibility. That part will be reverted soon again.