### PR TITLE
Fix write remote.url.pushUrl as /dev/null

### DIFF
--- a/git_toprepo.py
+++ b/git_toprepo.py
@@ -97,6 +97,11 @@ class MonoRepo(Repo):
                 ["git", "-C", str(self.path), "config", "remote.origin.url", fetch_url],
                 text=True,
             ).rstrip()
+            subprocess.check_output(
+                ["git", "-C", str(self.path)]
+                + ["config", "remote.origin.pushUrl", "file:///dev/null"],
+                text=True,
+            ).rstrip()
         # TODO: 2024-04-29 Remove after migration.
         push_url = self.get_toprepo_fetch_url_impl("remote.top.pushUrl", False)
         if push_url is None:


### PR DESCRIPTION
In the backwards compatible mode, remote.url.pushUrl=/dev/null should also be populated.