### PR TITLE
Fix pyproject.toml to include git_filter_repo_for_toprepo

### DIFF
--- a/git_toprepo.py
+++ b/git_toprepo.py
@@ -35,9 +35,12 @@ try:
     # TODO: Need git-filter-repo from source to allow Git 2.43.
     import git_filter_repo_for_toprepo as git_filter_repo  # type: ignore
 except ImportError:
-    print("ERROR: git-filter-repo is missing")
-    print("Please run:  python3 -m pip install git-filter-repo")
-    sys.exit(2)
+    try:
+        import git_filter_repo
+    except ImportError:
+        print("ERROR: git-filter-repo is missing")
+        print("Please run:  python3 -m pip install git-filter-repo")
+        sys.exit(2)
 
 # git-filter-repo runs `git reset --hard` after filtering. Disable that.
 original_git_filter_repo_cleanup = git_filter_repo.RepoFilter.cleanup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ keywords = ["git", "submodule", "monorepo", "toprepo", "superrepo"]
 authors = ["Fredrik Medley <fredrik@meroton.com>"]
 license = "GPL-3.0-only"
 readme = "README.md"
-include = ["git_filter_repo_for_toprepo.py"]
+include = [
+    { path = "git_filter_repo_for_toprepo.py", format = ["sdist", "wheel"] }
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
https://github.com/python-poetry/poetry-core/pull/773 merge 2024-10-13 stopped including "include" files into wheels by default. This update adds git_filter_repo_for_toprepo.py back into the wheel.

Fixes #38