### PR TITLE
Make the git-config toprepo.config mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,11 @@ The algorithm steps are:
 
 The configuration is specified in [Toml](https://toml.io/) format. The location
 of the configuration file is set in the git-config of the super repository using
-`git config --local toprepo.config <ref>:<git-repo-relative-path>` which
-defaults to `refs/remotes/origin/HEAD:.gittoprepo.toml`. An empty `ref`, for
-example `:.gittoprepo.user.toml`, means that the file is read from the worktree
-instead of the commits.
-
-Overriding the location is only recommended for testing out a new config and
-debugging purpose.
+`git config --local toprepo.config <location>`
+Where the location is either a git ref `ref:<ref>:<path>` or a local file
+`local:<path>`.
+By default the toprepo has a configuration through a git ref that is committed.
+But it is possible to override it with a local path.
 
 ### Sub repositories
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,25 +87,13 @@ pub struct Config {
 #[derive(Subcommand, Debug)]
 pub enum ConfigCommands {
     /// Prints the configuration location.
-    Location(ConfigLocation),
+    Location,
     /// Show the configuration of the current repository.
-    Show(ConfigShow),
+    Show,
     /// Reads a configuration and prints it in normalized form.
     Normalize(ConfigNormalize),
     /// Verifies that a given configuration can be loaded.
     Validate(ConfigValidate),
-}
-
-#[derive(Args, Debug)]
-pub struct ConfigLocation {
-    #[arg(short = 'v', long = "verbose")]
-    pub verbose: bool,
-}
-
-#[derive(Args, Debug)]
-pub struct ConfigShow {
-    #[arg(short = 'v', long = "verbose")]
-    pub verbose: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -105,6 +105,15 @@ impl TopRepo {
             .check_success()
             .context("Failed to set git-config remote.origin.tagOpt")?;
         git_command(&directory)
+            .args([
+                "config",
+                "toprepo.config",
+                "repo:refs/remotes/origin/HEAD:.gittoprepo.toml",
+            ])
+            .safe_status()?
+            .check_success()
+            .context("Failed to set git-config remote.origin.url")?;
+        git_command(&directory)
             .args(["symbolic-ref", "HEAD", "refs/remotes/origin/HEAD"])
             .safe_status()?
             .check_success()

--- a/src/util.rs
+++ b/src/util.rs
@@ -507,14 +507,14 @@ pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
 ///
 /// assert_eq!(trim_newline_suffix("foo\n\r"), "foo\n\r");
 /// ```
-pub fn trim_newline_suffix(s: &str) -> &str {
-    if let Some(stripped) = s.strip_suffix("\r\n") {
-        stripped
-    } else if let Some(stripped) = s.strip_suffix('\n') {
-        stripped
-    } else {
-        s
-    }
+pub fn trim_newline_suffix(line: &str) -> &str {
+    let Some(line) = line.strip_suffix('\n') else {
+        return line;
+    };
+    let Some(line) = line.strip_suffix('\r') else {
+        return line;
+    };
+    line
 }
 
 /// Removes trailing LF or CRLF from a byte string.


### PR DESCRIPTION
Let `git-toprepo init` initialize the git-config toprepo.config with a sane value. Then there is no need for auto-resolving a config location in case it is not configured. Another benefit is that git-toprepos can be identified by checking for the existence of the git-config key `toprepo.config`.