### PR TITLE
Validate user-provided config files before loading the repo itself

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,7 +103,7 @@ pub struct Config {
     pub config_command: ConfigCommands,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum ConfigCommands {
     /// Prints the configuration location.
     Location,
@@ -118,14 +118,14 @@ pub enum ConfigCommands {
     Validate(ConfigValidate),
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct ConfigNormalize {
     /// The configuration file to normalize or - for stdin.
     #[arg(id = "file")]
     pub file: PathBuf,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct ConfigValidate {
     /// The configuration file to validate or - for stdin.
     #[arg(id = "file")]

--- a/src/git.rs
+++ b/src/git.rs
@@ -384,21 +384,17 @@ pub fn repo_relative_path(worktree: &Path, cwd_relpath: &Path) -> Result<GitPath
     ))
 }
 
-#[cfg(test)]
-pub mod tests {
-    use std::collections::HashMap;
-
-    pub fn commit_env() -> HashMap<String, String> {
-        HashMap::from(
-            [
-                ("GIT_AUTHOR_NAME", "A Name"),
-                ("GIT_AUTHOR_EMAIL", "a@no.domain"),
-                ("GIT_AUTHOR_DATE", "2023-01-02T03:04:05Z+01:00"),
-                ("GIT_COMMITTER_NAME", "C Name"),
-                ("GIT_COMMITTER_EMAIL", "c@no.domain"),
-                ("GIT_COMMITTER_DATE", "2023-06-07T08:09:10Z+01:00"),
-            ]
-            .map(|(k, v)| (k.to_string(), v.to_string())),
-        )
-    }
+/// Scaffolding code to create deterministic commits.
+pub fn commit_env_for_testing() -> HashMap<String, String> {
+    HashMap::from(
+        [
+            ("GIT_AUTHOR_NAME", "A Name"),
+            ("GIT_AUTHOR_EMAIL", "a@no.domain"),
+            ("GIT_AUTHOR_DATE", "2023-01-02T03:04:05Z+01:00"),
+            ("GIT_COMMITTER_NAME", "C Name"),
+            ("GIT_COMMITTER_EMAIL", "c@no.domain"),
+            ("GIT_COMMITTER_DATE", "2023-06-07T08:09:10Z+01:00"),
+        ]
+        .map(|(k, v)| (k.to_string(), v.to_string())),
+    )
 }

--- a/tests/integration/config.rs
+++ b/tests/integration/config.rs
@@ -1,0 +1,104 @@
+use assert_cmd::prelude::*;
+use git_toprepo::config::GIT_CONFIG_KEY;
+use git_toprepo::git::commit_env_for_testing;
+use git_toprepo::git::git_command;
+use git_toprepo::util::CommandExtension as _;
+use predicates::prelude::*;
+use std::io::Write;
+use std::process::Command;
+
+const GENERIC_CONFIG: &str = r#"
+    [repo]
+    [repo.foo.fetch]
+    url = "ssh://generic/repo.git"
+"#;
+
+#[test]
+fn test_validate_external_file_in_corrupt_repository() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::TempDir::with_prefix("git-toprepo-").unwrap();
+    // Debug with &temp_dir.into_path() to persist the path.
+    let temp_dir = temp_dir.path();
+
+    // TODO: Set NO_COLOR here.
+    let deterministic = commit_env_for_testing();
+
+    let invalid_toml = "invalid.t.o.m.l";
+    let mut invalid_tomlfile = std::fs::File::create(temp_dir.join(invalid_toml))?;
+    writeln!(invalid_tomlfile, "nonesuch configuration. BEEP BOOP")?;
+
+    let incorrect_config = "incorrect.toml";
+    let mut incorrect_tomlfile = std::fs::File::create(temp_dir.join(incorrect_config))?;
+    writeln!(incorrect_tomlfile, "[Wrong.Key]")?;
+
+    let okay_config = "okay.toml";
+    let mut okay_file = std::fs::File::create(temp_dir.join(okay_config))?;
+    writeln!(okay_file, "{GENERIC_CONFIG}")?;
+
+    git_command(temp_dir)
+        .args(["init"])
+        .envs(&deterministic)
+        .check_success_with_stderr()?;
+
+    git_command(temp_dir)
+        .args(["config", GIT_CONFIG_KEY, &format!("local:{invalid_toml}")])
+        .envs(&deterministic)
+        .check_success_with_stderr()?;
+
+    // NB: We do not need to initialize the history for this test.
+
+    {
+        let mut cmd = Command::cargo_bin("git-toprepo")?;
+        cmd.current_dir(temp_dir).arg("config").arg("show");
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains(format!(
+                "ERROR: Parsing local:{invalid_toml}: Could not parse TOML string",
+            )));
+    }
+
+    // TODO: Rephrase the namespace in the error message. It looks ugly.
+    // TODO: Verify that a TOML-parse-error exit code is used.
+
+    {
+        let mut cmd = Command::cargo_bin("git-toprepo")?;
+        cmd.current_dir(temp_dir)
+            .arg("config")
+            .arg("validate")
+            .arg(invalid_toml);
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains(format!(
+                "ERROR: Loading config file {invalid_toml}: Could not parse TOML string",
+            )))
+            .stderr(predicate::str::contains("expected `.`, `=`"));
+    }
+
+    // TODO: Verify that a TOML-parse-error exit code is used.
+
+    {
+        let mut cmd = Command::cargo_bin("git-toprepo")?;
+        cmd.current_dir(temp_dir)
+            .arg("config")
+            .arg("validate")
+            .arg(incorrect_config);
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains(format!(
+                "ERROR: Loading config file {incorrect_config}: Could not parse TOML string",
+            )))
+            .stderr(predicate::str::contains(
+                "unknown field `Wrong`, expected `repo` or `log`",
+            ));
+    }
+
+    {
+        let mut cmd = Command::cargo_bin("git-toprepo")?;
+        cmd.current_dir(temp_dir)
+            .arg("config")
+            .arg("validate")
+            .arg(okay_config);
+        cmd.assert().success();
+    }
+
+    Ok(())
+}

--- a/tests/integration/fixtures/toprepo.rs
+++ b/tests/integration/fixtures/toprepo.rs
@@ -1,26 +1,13 @@
 use bstr::ByteSlice;
 use git_toprepo::git::CommitId;
 use git_toprepo::git::GitPath;
+use git_toprepo::git::commit_env_for_testing;
 use git_toprepo::git::git_command;
 use git_toprepo::git::git_update_submodule_in_index;
 use git_toprepo::util::CommandExtension as _;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
-
-pub fn commit_env() -> HashMap<String, String> {
-    HashMap::from(
-        [
-            ("GIT_AUTHOR_NAME", "A Name"),
-            ("GIT_AUTHOR_EMAIL", "a@no.domain"),
-            ("GIT_AUTHOR_DATE", "2023-01-02T03:04:05Z+01:00"),
-            ("GIT_COMMITTER_NAME", "C Name"),
-            ("GIT_COMMITTER_EMAIL", "c@no.domain"),
-            ("GIT_COMMITTER_DATE", "2023-06-07T08:09:10Z+01:00"),
-        ]
-        .map(|(k, v)| (k.into(), v.into())),
-    )
-}
 
 fn git_commit(repo: &Path, env: &HashMap<String, String>, message: &str) -> CommitId {
     let file_name = message.to_owned() + ".txt";
@@ -67,7 +54,7 @@ fn git_merge(repo: &Path, commit_ids: &[&CommitId]) {
         .args(["merge", "--no-ff", "--no-commit", "--strategy=ours"])
         .args(["-m", "Dummy"])
         .args(commit_ids)
-        .envs(commit_env())
+        .envs(commit_env_for_testing())
         .check_success_with_stderr()
         .unwrap();
 }
@@ -99,7 +86,7 @@ fn git_add_local_submodule_to_index(repo: &Path, path: &GitPath, url: &str) {
 ///                                    8b--------9b-----11--12----/
 /// ```
 /// The commit N is pointing to commit 11 in the submodule, which is a bad merge
-/// because even if N keeps the submodule K was pointong to, the submodule
+/// because even if N keeps the submodule K was pointing to, the submodule
 /// pointer goes backwards in relation to M.
 ///
 /// # Examples
@@ -132,7 +119,7 @@ impl GitTopRepoExample {
 
     /// Sets up the repo structure and returns the top repo path.
     pub fn init_server_top(&self) -> PathBuf {
-        let env = commit_env();
+        let env = commit_env_for_testing();
         let top_repo = self.tmp_path.join("top");
         let sub_repo = self.tmp_path.join("sub");
 
@@ -229,7 +216,7 @@ impl GitTopRepoExample {
 
     /// Sets up the repo structure and returns the top repo path.
     pub fn merge_with_one_submodule_a(&self) -> PathBuf {
-        let env = commit_env();
+        let env = commit_env_for_testing();
         let top_repo = self.tmp_path.join("top");
         let subx_repo = self.tmp_path.join("subx");
 
@@ -283,7 +270,7 @@ impl GitTopRepoExample {
 
     /// Sets up the repo structure and returns the top repo path.
     pub fn merge_with_one_submodule_b(&self) -> PathBuf {
-        let env = commit_env();
+        let env = commit_env_for_testing();
         let top_repo = self.tmp_path.join("top");
         let subx_repo = self.tmp_path.join("subx");
 
@@ -344,7 +331,7 @@ impl GitTopRepoExample {
 
     /// Sets up the repo structure and returns the top repo path.
     pub fn merge_with_two_submodules(&self) -> PathBuf {
-        let env = commit_env();
+        let env = commit_env_for_testing();
         let top_repo = self.tmp_path.join("top");
         let subx_repo = self.tmp_path.join("subx");
         let suby_repo = self.tmp_path.join("suby");
@@ -420,7 +407,7 @@ impl GitTopRepoExample {
 
     /// Sets up the repo structure and returns the top repo path.
     pub fn submodule_removal(&self) -> PathBuf {
-        let env = commit_env();
+        let env = commit_env_for_testing();
         let top_repo = self.tmp_path.join("top");
         let subx_repo = self.tmp_path.join("subx");
 
@@ -473,7 +460,7 @@ impl GitTopRepoExample {
 
     /// Sets up the repo structure and returns the top repo path.
     pub fn move_submodule(&self) -> PathBuf {
-        let env = commit_env();
+        let env = commit_env_for_testing();
         let top_repo = self.tmp_path.join("top");
         let subx_repo = self.tmp_path.join("subx");
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -5,6 +5,8 @@ mod cli;
 #[cfg(test)]
 mod clone;
 #[cfg(test)]
+mod config;
+#[cfg(test)]
 mod refilter;
 #[cfg(test)]
 mod workspace;


### PR DESCRIPTION
This can be used if the main configuration is invalid. Otherwise the main dispatch would not reach the config-validation code for the error with the repo's own config. Regardless of the validity of the user provided config file.