### PR TITLE
Require remote and refspec for push commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -175,12 +175,12 @@ pub struct Push {
 
     /// A configured git remote in the mono repository or a URL of the top
     /// repository to push to. Submodules are calculated relative this remote.
-    #[arg(name = "top-remote", default_value_t = String::from("origin"), verbatim_doc_comment)]
+    #[arg(name = "top-remote", verbatim_doc_comment)]
     pub top_remote: String,
 
     /// A reference to push from the top repository. Refspec wildcards are not
     /// supported.
-    #[arg(id = "refspec", num_args=1.., value_parser = clap::builder::ValueParser::new(parse_refspec), verbatim_doc_comment)]
+    #[arg(id = "refspec", required=true, num_args=1.., value_parser = clap::builder::ValueParser::new(parse_refspec), verbatim_doc_comment)]
     pub refspecs: Vec<(String, String)>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use crate::cli::Cli;
 use crate::cli::Commands;
 use anyhow::Context;
 use anyhow::Result;
-use anyhow::bail;
 use bstr::ByteSlice as _;
 use clap::Parser;
 use colored::Colorize;
@@ -438,11 +437,7 @@ fn push(push_args: &cli::Push) -> Result<ExitCode> {
 
     let refspecs = push_args.refspecs.as_slice();
     let [(local_ref, remote_ref)] = refspecs else {
-        if refspecs.is_empty() {
-            bail!("Missing remote or refspec")
-        } else {
-            unimplemented!("Handle multiple refspecs");
-        }
+        unimplemented!("Handle multiple refspecs");
     };
 
     let mut result = git_toprepo::log::log_task_to_stderr(


### PR DESCRIPTION
We can make `git toprepo push` fail early in command line parsing because of a couple of reasons:
* git-toprepo currently only supports using gerrit.
* creating a gerrit change requires commits to be pushed to a `refs/for/` namespace, and specifying refspec requires specifying the remote: git push origin HEAD:refs/for/master

Therefore since `git-toprepo push` aims to support the same workflow as `git push` we can make the remote and refspec(s) required for `git toprepo push`.