### PR TITLE
Add 'git-toprepo version' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "git_toprepo"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git_toprepo"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2024"
 
 [dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ git-toprepo merges subrepositories into a common history, similar to git-subtree
 ";
 
 #[derive(Parser, Debug)]
-#[command(version, about = ABOUT)]
+#[command(about = ABOUT)]
 pub struct Cli {
     /// Run as if started in <path>.
     #[arg(name = "path", short = 'C')]
@@ -48,7 +48,6 @@ pub enum GitEnum {
 }
 
 #[derive(Subcommand, Debug)]
-#[command(version)]
 pub enum Commands {
     /// Initialize a repository and the git-config, without fetching from the remote.
     Init(Init),
@@ -75,6 +74,9 @@ pub enum Commands {
     /// checkouts. For a git-toprepo super repo purposeful checkout must be
     /// implemented.
     Replace(Replace),
+    /// Print the version of the git-toprepo tool.
+    #[clap(aliases = ["-V", "--version"])]
+    Version,
 }
 
 #[derive(Args, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -482,6 +482,18 @@ fn dump_import_cache() -> Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
+/// Print the version of the git-toprepo to stdout.
+fn print_version() -> Result<()> {
+    println!(
+        "{} {}~{}-{}",
+        env!("CARGO_PKG_NAME"),
+        option_env!("BUILD_SCM_TAG").unwrap_or("0.0.0"),
+        option_env!("BUILD_SCM_TIMESTAMP").unwrap_or("timestamp"),
+        option_env!("BUILD_SCM_REVISION").unwrap_or("git-hash"),
+    );
+    Ok(())
+}
+
 fn main_impl<I>(argv: I) -> Result<ExitCode>
 where
     I: IntoIterator<Item = std::ffi::OsString>,
@@ -509,6 +521,7 @@ where
         }
         Commands::Config(config_args) => return config(config_args),
         Commands::Dump(dump_args) => return dump(dump_args),
+        Commands::Version => return print_version().map(|_| ExitCode::SUCCESS),
         _ => {
             if args.working_directory.is_none() {
                 let current_dir = std::env::current_dir()?;
@@ -537,6 +550,7 @@ where
             Commands::Push(push_args) => push(&push_args, processor, logger),
             Commands::Dump(_) => unreachable!("dump already processed"),
             Commands::Replace(_replace_args) => todo!(), //replace(&args, replace_args)?,
+            Commands::Version => unreachable!("version already processed"),
         }
     })
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -11,4 +11,6 @@ mod push;
 #[cfg(test)]
 mod refilter;
 #[cfg(test)]
+mod version;
+#[cfg(test)]
 mod workspace;

--- a/tests/integration/version.rs
+++ b/tests/integration/version.rs
@@ -1,0 +1,35 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+#[test]
+fn test_toprepo_version() {
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .arg("version")
+        .assert()
+        .success()
+        .stdout("git_toprepo 0.0.0~timestamp-git-hash\n")
+        .stderr("");
+}
+
+#[test]
+fn test_toprepo_dash_dash_version() {
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout("git_toprepo 0.0.0~timestamp-git-hash\n")
+        .stderr("");
+}
+
+#[test]
+fn test_toprepo_short_flag_version() {
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .arg("-V")
+        .assert()
+        .success()
+        .stdout("git_toprepo 0.0.0~timestamp-git-hash\n")
+        .stderr("");
+}


### PR DESCRIPTION
The version info is formed of the git tag, committer date and the git commit hash.

`git-toprepo -V` and `git-toprepo --version` are also available as aliases.