### PR TITLE
Use ErrorMode instead of interrupted AtomicBool

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -115,10 +115,14 @@ impl ErrorMode {
         }
     }
 
-    pub fn interrupted(&self) -> Arc<AtomicBool> {
+    /// Returns `true` if the error mode is `FailFast` and the processing
+    /// should be interrupted.
+    pub fn should_interrupt(&self) -> bool {
         match self {
-            ErrorMode::KeepGoing => Arc::new(AtomicBool::new(false)),
-            ErrorMode::FailFast(interrupted) => interrupted.clone(),
+            ErrorMode::KeepGoing => false,
+            ErrorMode::FailFast(interrupted) => {
+                interrupted.load(std::sync::atomic::Ordering::Relaxed)
+            }
         }
     }
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -38,7 +38,6 @@ use std::io::Write as _;
 use std::ops::Deref;
 use std::path::Path;
 use std::rc::Rc;
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct TopRepo {
@@ -212,7 +211,7 @@ pub struct MonoRepoProcessor {
     pub gix_repo: gix::ThreadSafeRepository,
     pub config: crate::config::GitTopRepoConfig,
     pub top_repo_cache: crate::repo::TopRepoCache,
-    pub interrupted: Arc<std::sync::atomic::AtomicBool>,
+    pub error_mode: crate::log::ErrorMode,
     pub progress: indicatif::MultiProgress,
 }
 
@@ -242,7 +241,7 @@ impl MonoRepoProcessor {
             gix_repo,
             config,
             top_repo_cache,
-            interrupted: error_mode.interrupted(),
+            error_mode: error_mode.clone(),
             progress: indicatif::MultiProgress::new(),
         };
         let mut result =


### PR DESCRIPTION
`ErrorMode` has a cleaner interface than an anonymous `AtomicBool`.