### PR TITLE
Rename build-and-test workflow to ci for cleaner UI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Build and test
+name: ci
 on:
   pull_request: {}
   push:
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest] # TODO: macos-latest, windows-latest
-    name: Test on ${{ matrix.os }}
+    name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     env:
       CARGO_TERM_COLOR: always
@@ -35,7 +35,7 @@ jobs:
         platform:
           - rust_target: x86_64-unknown-linux-musl
             suffix: .linux_amd64
-    name: Build for ${{ matrix.platform.rust_target }}
+    name: build (${{ matrix.platform.rust_target }})
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
@@ -63,6 +63,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
+    name: nix-build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     permissions:
       # Allow purging caches.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: release
 on:
   release:
     types:
@@ -9,14 +9,14 @@ permissions:
   contents: write
 
 jobs:
-  publish-artifacts:
+  publish:
     strategy:
       fail-fast: false
       matrix:
         platform:
           - rust_target: x86_64-unknown-linux-musl
             suffix: .linux_amd64
-    name: Release for ${{ matrix.platform.rust_target }}
+    name: publish (${{ matrix.platform.rust_target }})
     environment: release-on-github
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
The text "_Build and test / Build for x86_64-unknown-linux-musl_" is too repetitive. "_ci / build (x86_64-unknown-linux-musl)_" gives an improved overview.