### PR TITLE
Add configuration for skipping commits

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,12 @@
+use crate::git::CommitId;
 use crate::git::git_command;
 use crate::git::git_config_get;
 use crate::gitmodules::SubmoduleUrlExt as _;
 use crate::repo_name::RepoName;
 use crate::repo_name::SubRepoName;
 use crate::util::CommandExtension as _;
+use crate::util::OrderedHashMap;
+use crate::util::OrderedHashSet;
 use crate::util::is_default;
 use anyhow::Context;
 use anyhow::Result;
@@ -432,6 +435,19 @@ pub struct SubRepoConfig {
     #[serde(default = "return_true")]
     #[serde(skip_serializing_if = "is_true")]
     pub enabled: bool,
+    /// Commits that should not be expanded but rather kept as submodules. These
+    /// don't need to be fetched from the remote.
+    #[serde_as(
+        serialize_as = "serde_with::IfIsHumanReadable<OrderedHashSet<serde_with::DisplayFromStr>>"
+    )]
+    pub skip_expanding: HashSet<CommitId>,
+    /// Expand a different commit instead of the given. This is useful in case a
+    /// commit is missing or just represent a bad git history. By replacing a
+    /// commit by it's parent, the bump will effectively be removed.
+    #[serde_as(
+        serialize_as = "serde_with::IfIsHumanReadable<OrderedHashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>>"
+    )]
+    pub replace_commit: HashMap<CommitId, CommitId>,
 }
 
 fn return_true() -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,6 @@ use crate::gitmodules::SubmoduleUrlExt as _;
 use crate::repo_name::RepoName;
 use crate::repo_name::SubRepoName;
 use crate::util::CommandExtension as _;
-use crate::util::OrderedHashMap;
 use crate::util::OrderedHashSet;
 use crate::util::is_default;
 use anyhow::Context;
@@ -441,13 +440,6 @@ pub struct SubRepoConfig {
         serialize_as = "serde_with::IfIsHumanReadable<OrderedHashSet<serde_with::DisplayFromStr>>"
     )]
     pub skip_expanding: HashSet<CommitId>,
-    /// Expand a different commit instead of the given. This is useful in case a
-    /// commit is missing or just represent a bad git history. By replacing a
-    /// commit by it's parent, the bump will effectively be removed.
-    #[serde_as(
-        serialize_as = "serde_with::IfIsHumanReadable<OrderedHashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>>"
-    )]
-    pub replace_commit: HashMap<CommitId, CommitId>,
 }
 
 fn return_true() -> bool {

--- a/src/expander.rs
+++ b/src/expander.rs
@@ -287,28 +287,43 @@ impl TopRepoExpander<'_> {
                     let expanded_submod = if let Some(submod_repo_name) = &bump.repo_name {
                         let repo_name = RepoName::SubRepo(submod_repo_name.clone());
                         if self.config.is_enabled(&repo_name) {
-                            let submod_storage = self.storage.repos.get(&repo_name).unwrap();
-                            if let Some(submod_commit) =
-                                submod_storage.thin_commits.get(&bump.commit_id)
-                            {
-                                tree_updates.push((abs_sub_path.clone(), submod_commit.tree_id));
-                                self.get_recursive_submodule_bumps(
-                                    &abs_sub_path,
-                                    submod_commit,
-                                    submod_updates,
-                                    tree_updates,
-                                );
-                                // TODO: This might be a regression, but the caller
-                                // is not interested in that information anyway.
-                                ExpandedSubmodule::Expanded(SubmoduleContent {
-                                    repo_name: submod_repo_name.clone(),
-                                    orig_commit_id: bump.commit_id,
-                                })
+                            let subconfig = self
+                                .config
+                                .subrepos
+                                .get(submod_repo_name)
+                                .expect("submod name exists");
+                            if subconfig.skip_expanding.contains(&bump.commit_id) {
+                                ExpandedSubmodule::KeptAsSubmodule(bump.commit_id)
                             } else {
-                                ExpandedSubmodule::CommitMissingInSubRepo(SubmoduleContent {
-                                    repo_name: submod_repo_name.clone(),
-                                    orig_commit_id: bump.commit_id,
-                                })
+                                let bump_commit_id = subconfig
+                                    .replace_commit
+                                    .get(&bump.commit_id)
+                                    .cloned()
+                                    .unwrap_or(bump.commit_id);
+                                let submod_storage = self.storage.repos.get(&repo_name).unwrap();
+                                if let Some(submod_commit) =
+                                    submod_storage.thin_commits.get(&bump_commit_id)
+                                {
+                                    tree_updates
+                                        .push((abs_sub_path.clone(), submod_commit.tree_id));
+                                    self.get_recursive_submodule_bumps(
+                                        &abs_sub_path,
+                                        submod_commit,
+                                        submod_updates,
+                                        tree_updates,
+                                    );
+                                    // TODO: This might be a regression, but the caller
+                                    // is not interested in that information anyway.
+                                    ExpandedSubmodule::Expanded(SubmoduleContent {
+                                        repo_name: submod_repo_name.clone(),
+                                        orig_commit_id: bump_commit_id,
+                                    })
+                                } else {
+                                    ExpandedSubmodule::CommitMissingInSubRepo(SubmoduleContent {
+                                        repo_name: submod_repo_name.clone(),
+                                        orig_commit_id: bump.commit_id,
+                                    })
+                                }
                             }
                         } else {
                             // Repository disabled by config, keep the submodule.

--- a/src/expander.rs
+++ b/src/expander.rs
@@ -295,14 +295,9 @@ impl TopRepoExpander<'_> {
                             if subconfig.skip_expanding.contains(&bump.commit_id) {
                                 ExpandedSubmodule::KeptAsSubmodule(bump.commit_id)
                             } else {
-                                let bump_commit_id = subconfig
-                                    .replace_commit
-                                    .get(&bump.commit_id)
-                                    .cloned()
-                                    .unwrap_or(bump.commit_id);
                                 let submod_storage = self.storage.repos.get(&repo_name).unwrap();
                                 if let Some(submod_commit) =
-                                    submod_storage.thin_commits.get(&bump_commit_id)
+                                    submod_storage.thin_commits.get(&bump.commit_id)
                                 {
                                     tree_updates
                                         .push((abs_sub_path.clone(), submod_commit.tree_id));
@@ -316,7 +311,7 @@ impl TopRepoExpander<'_> {
                                     // is not interested in that information anyway.
                                     ExpandedSubmodule::Expanded(SubmoduleContent {
                                         repo_name: submod_repo_name.clone(),
-                                        orig_commit_id: bump_commit_id,
+                                        orig_commit_id: bump.commit_id,
                                     })
                                 } else {
                                     ExpandedSubmodule::CommitMissingInSubRepo(SubmoduleContent {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -437,7 +437,12 @@ impl<'a> CommitLoader<'a> {
                 if self.fetch_missing_commits && !repo_fetcher.needed_commits.is_empty() {
                     if repo_fetcher.fetching_default_refspec_done() {
                         let missing_commits = std::mem::take(&mut repo_fetcher.needed_commits);
-                        Self::add_missing_commits(repo_name, missing_commits, repo_fetcher);
+                        Self::add_missing_commits(
+                            repo_name,
+                            missing_commits,
+                            &mut repo_fetcher.missing_commits,
+                            &self.logger,
+                        );
                     } else {
                         self.fetch_repo(repo_name.clone());
                     }
@@ -448,16 +453,16 @@ impl<'a> CommitLoader<'a> {
     }
 
     fn add_missing_commits(
-        _repo_name: &RepoName,
+        repo_name: &RepoName,
         missing_commits: HashSet<CommitId>,
-        repo_fetcher: &mut RepoFetcher,
+        all_missing_commits: &mut HashSet<CommitId>,
+        logger: &Logger,
     ) {
         // Already logged when loading the repositories.
-        // for commit_id in &missing_commits {
-        //     self.logger
-        //         .warning(format!("Missing commit in {repo_name}: {commit_id}"));
-        // }
-        repo_fetcher.missing_commits.extend(missing_commits);
+        for commit_id in &missing_commits {
+            logger.warning(format!("Missing commit in {repo_name}: {commit_id}"));
+        }
+        all_missing_commits.extend(missing_commits);
     }
 
     fn load_cached_commits(
@@ -534,10 +539,22 @@ impl<'a> CommitLoader<'a> {
                     if let ThinSubmodule::AddedOrModified(bump) = bump
                         && let Some(submod_repo_name) = &bump.repo_name
                     {
-                        needed_commits.push(NeededCommit {
-                            repo_name: submod_repo_name.clone(),
-                            commit_id: bump.commit_id,
-                        });
+                        let subconfig = self
+                            .config
+                            .subrepos
+                            .get(submod_repo_name)
+                            .expect("subrepo name exists");
+                        if !subconfig.skip_expanding.contains(&bump.commit_id) {
+                            let needed_commit_id = subconfig
+                                .replace_commit
+                                .get(&bump.commit_id)
+                                .cloned()
+                                .unwrap_or(bump.commit_id);
+                            needed_commits.push(NeededCommit {
+                                repo_name: submod_repo_name.clone(),
+                                commit_id: needed_commit_id,
+                            });
+                        }
                     }
                 }
                 // TODO: The without_committer_id for thin_commit might not be
@@ -693,9 +710,14 @@ impl<'a> CommitLoader<'a> {
         let repo_name: RepoName = RepoName::SubRepo(needed_commit.repo_name);
         let commit_id = needed_commit.commit_id;
         // Already loaded?
+        if !self.repos.contains_key(&repo_name) {
+            self.create_repo_fetcher(&repo_name)
+                .expect("repo_name has been found in the configuration");
+        }
         let repo_fetcher = self
-            .get_or_create_repo_fetcher(&repo_name)
-            .expect("repo_name has been found in the configuration");
+            .repos
+            .get_mut(&repo_name)
+            .expect("repo_fetch just inserted");
         if repo_fetcher.repo_data.thin_commits.contains_key(&commit_id)
             || repo_fetcher.missing_commits.contains(&commit_id)
         {
@@ -717,7 +739,12 @@ impl<'a> CommitLoader<'a> {
                 if repo_fetcher.fetching_default_refspec_done() {
                     let mut missing_commits = HashSet::new();
                     missing_commits.insert(commit_id);
-                    Self::add_missing_commits(&repo_name, missing_commits, repo_fetcher);
+                    Self::add_missing_commits(
+                        &repo_name,
+                        missing_commits,
+                        &mut repo_fetcher.missing_commits,
+                        &self.logger,
+                    );
                 } else {
                     repo_fetcher.needed_commits.insert(commit_id);
                     if self.fetch_missing_commits {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -545,14 +545,9 @@ impl<'a> CommitLoader<'a> {
                             .get(submod_repo_name)
                             .expect("subrepo name exists");
                         if !subconfig.skip_expanding.contains(&bump.commit_id) {
-                            let needed_commit_id = subconfig
-                                .replace_commit
-                                .get(&bump.commit_id)
-                                .cloned()
-                                .unwrap_or(bump.commit_id);
                             needed_commits.push(NeededCommit {
                                 repo_name: submod_repo_name.clone(),
-                                commit_id: needed_commit_id,
+                                commit_id: bump.commit_id,
                             });
                         }
                     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -159,7 +159,6 @@ where
 
 /// A wrapper around `HashSet<T>` that serializes the entries in sorted order.
 /// This is useful when comparing JSON serialized data.
-#[allow(unused)]
 pub(crate) struct OrderedHashSet<T> {
     phantom: std::marker::PhantomData<T>,
 }


### PR DESCRIPTION
Some submodule gitlinks point to commits that will never exist. Don't
even try to fetch them.