### PR TITLE
Add fetch tests and fetch+refilter

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -206,10 +206,10 @@ impl GitTopRepoConfig {
         }
         matching_names.sort();
         let repo_name = match matching_names.as_slice() {
-            [] => anyhow::bail!("No configured submodule matches {wanted_url_str}"),
+            [] => anyhow::bail!("No configured submodule URL matches {wanted_url_str:?}"),
             [repo_name] => repo_name.clone(),
             [_, ..] => anyhow::bail!(
-                "Multiple configured repos match: {}",
+                "URLs from multiple configured repos match: {}",
                 matching_names
                     .iter()
                     .map(|name| name.to_string())

--- a/src/git_fast_export_import.rs
+++ b/src/git_fast_export_import.rs
@@ -594,6 +594,11 @@ impl FastImportRepo {
             out.write_all(b"\n")?;
         }
 
+        if !commit.branch.as_bstr().starts_with(b"refs/") {
+            // git 2.46.0 does not allow updating pseudo refs:
+            // https://github.com/git/git/commit/8e4f5c2dc26e8e88c8c4784f133d2b35a771d2ac
+            bail!("Branch name must start with refs/, got {:?}", commit.branch);
+        }
         out.write_all(b"commit ")?;
         out.write_all(commit.branch.as_bstr())?;
         out.write_all(b"\n")?;

--- a/tests/integration/clone.rs
+++ b/tests/integration/clone.rs
@@ -72,8 +72,8 @@ fn test_toprepo_clone() {
         .unwrap();
 
     let ref_pairs = vec![
-        ("HEAD", "refs/namespaces/top/HEAD"),
-        ("main", "refs/namespaces/top/refs/heads/main"),
+        ("HEAD", "refs/namespaces/top/refs/remotes/origin/HEAD"),
+        ("main", "refs/namespaces/top/refs/remotes/origin/main"),
         ("mytag", "refs/namespaces/top/refs/tags/mytag"),
     ];
     for (orig_ref, top_ref) in ref_pairs {

--- a/tests/integration/fetch.rs
+++ b/tests/integration/fetch.rs
@@ -1,0 +1,426 @@
+use assert_cmd::prelude::*;
+use git_toprepo::git::commit_env_for_testing;
+use predicates::prelude::*;
+use rstest::rstest;
+use std::process::Command;
+
+#[test]
+fn test_fetch_only_needed_commits() {
+    let temp_dir = gix_testtools::scripted_fixture_writable(
+        "../integration/fixtures/make_minimal_with_two_submodules.sh",
+    )
+    .unwrap();
+    let temp_dir = temp_dir.path();
+    let toprepo = temp_dir.join("top");
+    let monorepo = temp_dir.join("mono");
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    const RANDOM_SHA1: &str = "0123456789abcdef0123456789abcdef01234567";
+    Command::new("git")
+        .current_dir(&toprepo)
+        .args([
+            "update-index",
+            "--cacheinfo",
+            &format!("160000,{RANDOM_SHA1},subx"),
+        ])
+        .assert()
+        .success();
+    Command::new("git")
+        .current_dir(&toprepo)
+        .args(["commit", "-m", "Update submodule subx"])
+        .envs(commit_env_for_testing())
+        .assert()
+        .success();
+    // Make sure suby cannot be fetched, as it is not needed.
+    let suby_repo = temp_dir.join("suby");
+    assert!(suby_repo.is_dir());
+    std::fs::remove_dir_all(&suby_repo).unwrap();
+
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .current_dir(&monorepo)
+        .args(["fetch"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!(
+            "WARNING: Missing commit in subx: {RANDOM_SHA1}\n"
+        )));
+
+    // Check the filter result.
+    Command::new("git")
+        .current_dir(&monorepo)
+        .args(["ls-tree", "-r", "origin/main"])
+        .assert()
+        .success()
+        .stdout(
+            "\
+100644 blob 73bf371d38ac93f7592bdee317c8ea53fead1c8c\t.gitmodules
+100644 blob ed6ed9e7ce37c1f13f718aeaf54c522610a994c2\t.gittoprepo.toml
+100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tA1-main.txt
+160000 commit 0123456789abcdef0123456789abcdef01234567\tsubx
+100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tsuby/y-main-1.txt
+",
+        );
+
+    // After updating suby, fetch should fail as the suby remote is missing.
+    Command::new("git")
+        .current_dir(&toprepo)
+        .args([
+            "update-index",
+            "--cacheinfo",
+            &format!("160000,{RANDOM_SHA1},suby"),
+        ])
+        .assert()
+        .success();
+    Command::new("git")
+        .current_dir(&toprepo)
+        .args(["commit", "-m", "Update submodule suby"])
+        .envs(commit_env_for_testing())
+        .assert()
+        .success();
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .current_dir(&monorepo)
+        .args(["fetch"])
+        .assert()
+        .code(1)
+        .stderr(
+            predicate::str::is_match(
+                "ERROR: Fetching suby: git fetch .*/suby/ failed: exit status: 128",
+            )
+            .unwrap(),
+        )
+        .stderr(
+            predicate::str::is_match("fatal: '.*' does not appear to be a git repository").unwrap(),
+        )
+        .stderr(predicate::str::contains(
+            "fatal: Could not read from remote repository.",
+        ));
+
+    // Check the filter result, suby should not be updated as fetching failed.
+    Command::new("git")
+        .current_dir(&monorepo)
+        .args(["ls-tree", "-r", "origin/main"])
+        .assert()
+        .success()
+        .stdout(
+            "\
+100644 blob 73bf371d38ac93f7592bdee317c8ea53fead1c8c\t.gitmodules
+100644 blob ed6ed9e7ce37c1f13f718aeaf54c522610a994c2\t.gittoprepo.toml
+100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tA1-main.txt
+160000 commit 0123456789abcdef0123456789abcdef01234567\tsubx
+100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tsuby/y-main-1.txt
+",
+        );
+}
+
+struct RepoWithTwoSubmodules {
+    // TODO: Using #[allow(unused)] because the members will probably be used in
+    // the near future.
+    #[allow(unused)]
+    temp_dir: tempfile::TempDir,
+    pub toprepo: std::path::PathBuf,
+    pub monorepo: std::path::PathBuf,
+    #[allow(unused)]
+    pub subx_repo: std::path::PathBuf,
+    #[allow(unused)]
+    pub suby_repo: std::path::PathBuf,
+}
+
+impl RepoWithTwoSubmodules {
+    pub fn new_minimal_with_two_submodules() -> Self {
+        let temp_dir_guard = gix_testtools::scripted_fixture_writable(
+            "../integration/fixtures/make_minimal_with_two_submodules.sh",
+        )
+        .unwrap();
+        let temp_dir = temp_dir_guard.path().to_owned();
+        let toprepo = temp_dir.join("top");
+        let monorepo = temp_dir.join("mono");
+        crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+        std::fs::create_dir(monorepo.join("subdir_part_of_top")).unwrap();
+
+        Command::new("git")
+            .current_dir(&toprepo)
+            .args(["checkout", "-b", "foo"])
+            .assert()
+            .success();
+        Command::new("git")
+            .current_dir(&toprepo)
+            .args(["commit", "--allow-empty", "-m", "Empty test commit in top"])
+            .envs(commit_env_for_testing())
+            .assert()
+            .success();
+        // Make sure suby cannot be fetched, as it is not needed.
+        let suby_repo = temp_dir.join("suby");
+        assert!(suby_repo.is_dir());
+        std::fs::remove_dir_all(&suby_repo).unwrap();
+
+        Self {
+            temp_dir: temp_dir_guard,
+            toprepo,
+            monorepo,
+            subx_repo: temp_dir.join("subx"),
+            suby_repo: temp_dir.join("suby"),
+        }
+    }
+}
+
+#[rstest]
+#[case::no_remote(None)]
+#[case::origin(Some("origin"))]
+fn test_fetch_no_refspec_success(#[case] remote: Option<&str>) {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    let mut cmd = Command::cargo_bin("git-toprepo").unwrap();
+    cmd.current_dir(&repo.monorepo).arg("fetch");
+    if let Some(remote) = remote {
+        cmd.arg(remote);
+    }
+    cmd.assert().success();
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show", "--format=%s", "--quiet", "origin/foo"])
+        .assert()
+        .success()
+        .stdout("Empty test commit in top\n");
+}
+
+#[rstest]
+#[case::local_root_dir(".")]
+#[case::local_subdir("subdir_part_of_top")]
+fn test_fetch_no_refspec_fail(#[case] remote: &str) {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .current_dir(&repo.monorepo)
+        .args(["fetch", remote])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(format!(
+            "ERROR: Failed to fetch: The git-remote {remote:?} was not found among \"origin\".\n\
+                When no refspecs are provided, a name among `git remote -v` must be specified.\n",
+        )));
+}
+
+/// It is not possible to fetch a refspec without a remote.
+#[test]
+fn test_fetch_refspec_no_remote() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .current_dir(&repo.monorepo)
+        .args(["fetch", "refs/heads/foo"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "ERROR: Failed to fetch: The git-remote \"refs/heads/foo\" was not found among \"origin\".\n\
+            When no refspecs are provided, a name among `git remote -v` must be specified.\n",
+        ));
+}
+
+#[rstest]
+#[case::origin("origin")]
+#[case::local_root_dir(".")]
+fn test_fetch_to_fetch_head_success(#[case] remote: &str) {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .current_dir(&repo.monorepo)
+        .args(["fetch", remote, "refs/heads/foo"])
+        .assert()
+        .success();
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show", "--format=%s", "--quiet", "FETCH_HEAD", "--"])
+        .assert()
+        .success()
+        .stdout("Empty test commit in top\n");
+    // Check that no extra temporary refs are available.
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show-ref"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(
+                [
+                    ".* refs/namespaces/subx/refs/heads/main\n",
+                    ".* refs/namespaces/suby/refs/heads/main\n",
+                    ".* refs/namespaces/top/refs/remotes/origin/HEAD\n",
+                    ".* refs/namespaces/top/refs/remotes/origin/main\n",
+                    ".* refs/remotes/origin/HEAD\n",
+                    ".* refs/remotes/origin/main\n",
+                ]
+                .join(""),
+            )
+            .unwrap(),
+        );
+}
+
+#[rstest]
+#[case::local_subdir("subdir_part_of_top")]
+fn test_fetch_to_fetch_head_fail(#[case] remote: &str) {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    Command::cargo_bin("git-toprepo").unwrap()
+    .current_dir(&repo.monorepo).args(["fetch", remote, "refs/heads/foo"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(
+            format!(
+                "ERROR: Submodule {remote} not found in config: subdir_part_of_top is not a submodule\n",
+            ),
+        ));
+}
+
+#[rstest]
+#[case::origin("origin")]
+#[case::local_root_dir(".")]
+fn test_fetch_refspec_success(#[case] remote: &str) {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .current_dir(&repo.monorepo)
+        .args(["fetch", remote, "refs/heads/foo:refs/heads/bar"])
+        .assert()
+        .success();
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show", "--format=%s", "--quiet", "refs/heads/bar", "--"])
+        .assert()
+        .success()
+        .stdout("Empty test commit in top\n");
+    // Check that no extra temporary refs are available.
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show-ref"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(
+                [
+                    ".* refs/namespaces/subx/refs/heads/main\n",
+                    ".* refs/namespaces/suby/refs/heads/main\n",
+                    ".* refs/namespaces/top/refs/remotes/origin/HEAD\n",
+                    ".* refs/namespaces/top/refs/remotes/origin/main\n",
+                    ".* refs/remotes/origin/HEAD\n",
+                    ".* refs/remotes/origin/main\n",
+                ]
+                .join(""),
+            )
+            .unwrap(),
+        );
+}
+
+#[rstest]
+#[case::local_subdir("subdir_part_of_top")]
+fn test_fetch_refspec_fail(#[case] remote: &str) {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    Command::cargo_bin("git-toprepo").unwrap()
+    .current_dir(&repo.monorepo).args(["fetch", remote, "refs/heads/foo:refs/heads/bar"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(
+            format!(
+                "ERROR: Submodule {remote} not found in config: subdir_part_of_top is not a submodule\n",
+            ),
+        ));
+}
+
+#[test]
+fn test_fetch_force_refspec_not_implemented_yet() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .current_dir(&repo.monorepo)
+        .args([
+            "fetch",
+            "origin",
+            "refs/heads/foo:refs/heads/bar",
+            "refs/heads/foo",
+        ])
+        .assert()
+        .success();
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show", "--format=%s", "--quiet", "refs/heads/bar", "--"])
+        .assert()
+        .success()
+        .stdout("Empty test commit in top\n");
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show", "--format=%s", "--quiet", "FETCH_HEAD", "--"])
+        .assert()
+        .success()
+        .stdout("Empty test commit in top\n");
+    // Amend so that force is needed.
+    Command::new("git")
+        .current_dir(&repo.toprepo)
+        .envs(commit_env_for_testing())
+        .args([
+            "commit",
+            "--amend",
+            "--allow-empty",
+            "-m",
+            "Updated test commit",
+        ])
+        .assert()
+        .success();
+    // git-fetch without force should fail.
+    // TODO: Not implemented yet.
+    // Command::cargo_bin("git-toprepo")
+    //     .unwrap()
+    //     .current_dir(&repo.monorepo)
+    //     .args(["fetch", "origin", "refs/heads/foo:refs/heads/bar"])
+    //     .assert()
+    //     .failure();
+    // Command::cargo_bin("git-toprepo")
+    //     .unwrap()
+    //     .current_dir(&repo.monorepo)
+    //     .args(["fetch", "origin", "refs/heads/foo"])
+    //     .assert()
+    //     .failure();
+    // git-fetch with force should succeed.
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .current_dir(&repo.monorepo)
+        .args([
+            "fetch",
+            "origin",
+            "+refs/heads/foo:refs/heads/bar",
+            "+refs/heads/foo",
+        ])
+        .assert()
+        .success();
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show", "--format=%s", "--quiet", "refs/heads/bar", "--"])
+        .assert()
+        .success()
+        .stdout("Updated test commit\n");
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show", "--format=%s", "--quiet", "FETCH_HEAD", "--"])
+        .assert()
+        .success()
+        .stdout("Updated test commit\n");
+    // Check that no extra temporary refs are available.
+    Command::new("git")
+        .current_dir(&repo.monorepo)
+        .args(["show-ref"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(
+                [
+                    ".* refs/heads/bar\n",
+                    ".* refs/namespaces/subx/refs/heads/main\n",
+                    ".* refs/namespaces/suby/refs/heads/main\n",
+                    ".* refs/namespaces/top/refs/remotes/origin/HEAD\n",
+                    ".* refs/namespaces/top/refs/remotes/origin/main\n",
+                    ".* refs/remotes/origin/HEAD\n",
+                    ".* refs/remotes/origin/main\n",
+                ]
+                .join(""),
+            )
+            .unwrap(),
+        );
+}

--- a/tests/integration/fixtures/make_minimal_with_two_submodules.sh
+++ b/tests/integration/fixtures/make_minimal_with_two_submodules.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+function commit {
+    local repo="$1"
+    local message="$2"
+    touch "${repo}/${message}.txt"
+    git -C "$repo" add "${message}.txt"
+    git -C "$repo" commit -q -m "$message"
+    git -C "$repo" rev-parse HEAD
+}
+
+mkdir top
+mkdir subx
+mkdir suby
+git -C top init -q --initial-branch main
+git -C subx init -q --initial-branch main
+git -C suby init -q --initial-branch main
+cat <<EOF > top/.gittoprepo.toml
+[repo.subx]
+urls = ["../subx/"]
+[repo.suby]
+urls = ["../suby/"]
+EOF
+git -C top add .gittoprepo.toml
+
+# Create the following commit history for:
+# subX/Y-main  1
+#              |
+# top-main     A
+
+subx_rev_1=$(commit subx "x-main-1")
+suby_rev_1=$(commit suby "y-main-1")
+
+git -C top -c protocol.file.allow=always submodule add --force ../subx/ subx
+git -C top -c protocol.file.allow=always submodule add --force ../suby/ suby
+git -C top submodule deinit -f subx suby
+git -C top update-index --cacheinfo "160000,${subx_rev_1},subx"
+git -C top update-index --cacheinfo "160000,${suby_rev_1},suby"
+commit top "A1-main"

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -9,6 +9,8 @@ mod config;
 #[cfg(test)]
 mod dump;
 #[cfg(test)]
+mod fetch;
+#[cfg(test)]
 mod push;
 #[cfg(test)]
 mod refilter;


### PR DESCRIPTION
Fetching refspecs did not really work before. This commit removes the assumption of 'origin' as remote name, which also means that filtered commits are not stored under `refs/remotes/origin/*` any more. To find filtered commits, .git/toprepo/mono-refs is written to log which refs are okay to remove in future pruning filtering operations. The default refspecs also had to be changed from `refs/heads/*:refs/namespaces/top/refs/heads/*` to `refs/heads/*:refs/namespaces/top/refs/remotes/origin/*` to accomodate a simplified input-output branch conversion rule, now simply strip-prefix.