### PR TITLE
Better git-toprepo --version output for nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,8 +26,6 @@
             cargo = toolchain;
             rustc = toolchain;
         };
-        git-toprepo = let
-          
           fs = inputs.nixpkgs.lib.fileset;
           src = fs.toSource {
             root = ./.;
@@ -38,45 +36,42 @@
               ./Cargo.toml
             ];
           };
-        # Use a fixed sha1 and timestamp to make the build cacheable.
-        # invalid timestamp that we assumen won't be present in the binary
-        # unless it's set by the `BUILD_SCM_TIMESTAMP`
-        fakeTimestamp = "19691332246060";
-        # sha1 generated with 'printf "git-toprepo" | sha1sum'
-        fakeRev = "a47761350505d860d99bac0bed8e02303874b689";
-        git-toprepo-cargo-bin = rustPlatform.buildRustPackage {
-            inherit src;
-            name = "git-toprepo";
-            BUILD_SCM_TAG = "nix";
-            BUILD_SCM_TIMESTAMP = fakeTimestamp;
-            BUILD_SCM_REVISION = fakeRev;
-            nativeBuildInputs = with pkgs; [
-                git
-            ];
-            cargoLock.lockFile = "${src}/Cargo.lock";
-          };
-        git-toprepo-patched = let
-            revision = if (self ? rev) then self.rev else self.dirtyRev;
-            timestamp = self.lastModifiedDate;
-          in pkgs.runCommand "git-toprepo-patched" {
-                PATH = pkgs.lib.strings.makeSearchPath "bin" [
-                  pkgs.gnused
-                ];
-              } ''
-            mkdir -p $out/bin
-            newRev="$(printf "${revision}" | sed 's/^\(.\{34\}\).*-dirty$/\1-dirty/')"
-            sed \
-              -e "s/${fakeRev}/$newRev/" \
-              -e "s/${fakeTimestamp}/${timestamp}/" \
-            ${git-toprepo-cargo-bin}/bin/git-toprepo \
-            > $out/bin/git-toprepo
-            chmod +x $out/bin/git-toprepo
-          '';
-        in git-toprepo-patched;
+          # Use a fixed fake sha1 and timestamp to make the build cacheable.
+          fakeTimestamp = "-NO_TIMESTAMP-";
+          fakeRev =   "---------------NO_VERSION---------------";
+          git-toprepo-unpatched = rustPlatform.buildRustPackage {
+              inherit src;
+              name = "git-toprepo";
+              BUILD_SCM_TAG = "nix";
+              BUILD_SCM_TIMESTAMP = fakeTimestamp;
+              BUILD_SCM_REVISION = fakeRev;
+              nativeBuildInputs = with pkgs; [
+                  git
+              ];
+              cargoLock.lockFile = "${src}/Cargo.lock";
+            };
+          git-toprepo-patched = let
+              revision = if (self ? rev) then self.rev else self.dirtyRev;
+              timestamp = self.lastModifiedDate;
+            in pkgs.runCommand "git-toprepo-patched" {
+                  PATH = pkgs.lib.strings.makeSearchPath "bin" [
+                    pkgs.gnused
+                  ];
+                } ''
+              mkdir -p $out/bin
+              newRev="$(printf "${revision}" | sed 's/^\(.\{34\}\).*-dirty$/\1-dirty/')"
+              sed \
+                -e "s/${fakeRev}/$newRev/" \
+                -e "s/${fakeTimestamp}/${timestamp}/" \
+              ${git-toprepo-unpatched}/bin/git-toprepo \
+              > $out/bin/git-toprepo
+              chmod +x $out/bin/git-toprepo
+            '';
         in {
           packages = {
-            inherit git-toprepo;
-            default =  git-toprepo;
+            inherit git-toprepo-unpatched;
+            git-toprepo = git-toprepo-patched;
+            default =  git-toprepo-patched;
           };
           devShells.default = pkgs.mkShell {
             buildInputs = [
@@ -86,7 +81,7 @@
           apps = let
               git-toprepo-app = {
                 type = "app";
-                program = "${git-toprepo}/bin/git-toprepo";
+                program = "${git-toprepo-patched}/bin/git-toprepo";
               };
             in {
               default = git-toprepo-app;


### PR DESCRIPTION
Now git-toprepo --version outputs the commit revision it was built with and the timestamp of that commit.

The cargo build is still cacheable since we use a fixed timestamp and revision that we replace in a later derivation.