### PR TITLE
Rename crate from git_toprepo to git-toprepo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "git_toprepo"
+name = "git-toprepo"
 version = "0.0.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
-name = "git_toprepo"
+name = "git-toprepo"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [dependencies]

--- a/tests/integration/version.rs
+++ b/tests/integration/version.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 #[test]
 fn test_toprepo_version() {
-    let validate_stdout = predicate::str::is_match("^git_toprepo .*~.*-.*\n$").unwrap();
+    let validate_stdout = predicate::str::is_match("^git-toprepo .*~.*-.*\n$").unwrap();
     Command::cargo_bin("git-toprepo")
         .unwrap()
         .arg("version")
@@ -16,7 +16,7 @@ fn test_toprepo_version() {
 
 #[test]
 fn test_toprepo_dash_dash_version() {
-    let validate_stdout = predicate::str::is_match("^git_toprepo .*~.*-.*\n$").unwrap();
+    let validate_stdout = predicate::str::is_match("^git-toprepo .*~.*-.*\n$").unwrap();
     Command::cargo_bin("git-toprepo")
         .unwrap()
         .arg("--version")
@@ -28,7 +28,7 @@ fn test_toprepo_dash_dash_version() {
 
 #[test]
 fn test_toprepo_short_flag_version() {
-    let validate_stdout = predicate::str::is_match("^git_toprepo .*~.*-.*\n$").unwrap();
+    let validate_stdout = predicate::str::is_match("^git-toprepo .*~.*-.*\n$").unwrap();
     Command::cargo_bin("git-toprepo")
         .unwrap()
         .arg("-V")


### PR DESCRIPTION
Hyphens are more common than underscore in crate names.