### PR TITLE
Use GIT_TOPREPO_KEEP_TEMP_DIR=1 to persist test dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!/lib
 lib64/
 parts/
 sdist/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "git-toprepo-testtools",
  "gix",
  "gix-testtools",
  "hex",
@@ -705,6 +706,14 @@ dependencies = [
  "threadpool",
  "toml",
  "url",
+]
+
+[[package]]
+name = "git-toprepo-testtools"
+version = "0.0.0"
+dependencies = [
+ "rstest",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 license = "MIT OR Apache-2.0"
 edition = "2024"
 
+[workspace]
+members = ["lib/testtools"]
+
 [dependencies]
 anyhow = "1.0.86"
 bincode = { version = "2.0.1", features = ["serde"] }
@@ -30,6 +33,7 @@ url = "2.5.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"
+git-toprepo-testtools = { path = "lib/testtools" }
 gix-testtools = "0.16.1"
 predicates = "3.1.3"
 rstest = "0.25.0"

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
           src = fs.toSource {
             root = ./.;
             fileset = fs.unions [
+              ./lib
               ./src
               ./tests
               ./Cargo.lock

--- a/lib/testtools/Cargo.toml
+++ b/lib/testtools/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "git-toprepo-testtools"
+version = "0.0.0"
+description = "Test utilities for git-toprepo."
+license = "MIT OR Apache-2.0"
+edition = "2024"
+
+[lib]
+name = "git_toprepo_testtools"
+path = "lib.rs"
+
+[dependencies]
+rstest = "0.25.0"
+tempfile = "3.13.0"

--- a/lib/testtools/lib.rs
+++ b/lib/testtools/lib.rs
@@ -1,0 +1,1 @@
+pub mod test_util;

--- a/lib/testtools/test_util.rs
+++ b/lib/testtools/test_util.rs
@@ -1,0 +1,122 @@
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::ops::Deref;
+
+pub enum MaybePermanentTempDir {
+    Keep(std::path::PathBuf),
+    Discard(tempfile::TempDir),
+}
+
+impl MaybePermanentTempDir {
+    /// Creates a new temporary directory, that may be kept permanently,
+    /// with a certain prefix.
+    ///
+    /// See also [`maybe_keep_tempdir`].
+    pub fn new_with_prefix(prefix: &str) -> Self {
+        let tempdir = tempfile::TempDir::with_prefix(prefix)
+            .expect("successful temporary directory creation");
+        maybe_keep_tempdir(tempdir)
+    }
+
+    pub fn path(&self) -> &std::path::Path {
+        match self {
+            MaybePermanentTempDir::Keep(path) => path,
+            MaybePermanentTempDir::Discard(tempdir) => tempdir.path(),
+        }
+    }
+}
+
+impl Deref for MaybePermanentTempDir {
+    type Target = std::path::Path;
+
+    fn deref(&self) -> &Self::Target {
+        self.path()
+    }
+}
+
+impl AsRef<std::path::Path> for MaybePermanentTempDir {
+    fn as_ref(&self) -> &std::path::Path {
+        self.path()
+    }
+}
+
+impl AsRef<OsStr> for MaybePermanentTempDir {
+    fn as_ref(&self) -> &OsStr {
+        self.path().as_os_str()
+    }
+}
+
+impl From<tempfile::TempDir> for MaybePermanentTempDir {
+    /// Persist a temporary directory to disk if the environment variable
+    /// `GIT_TOPREPO_KEEP_TEMP_DIR` is set to `1`,
+    ///
+    /// # Examples
+    ///
+    /// See the unit tests.
+    fn from(tempdir: tempfile::TempDir) -> Self {
+        let keep_var = std::env::var_os("GIT_TOPREPO_KEEP_TEMP_DIR");
+        maybe_keep_tempdir_impl(tempdir, keep_var)
+    }
+}
+
+/// Persist a temporary directory to disk if the environment variable
+/// `GIT_TOPREPO_KEEP_TEMP_DIR` is set to `1`,
+///
+/// # Examples
+///
+/// See the unit tests.
+pub fn maybe_keep_tempdir(tempdir: tempfile::TempDir) -> MaybePermanentTempDir {
+    MaybePermanentTempDir::from(tempdir)
+}
+
+pub(crate) fn maybe_keep_tempdir_impl(
+    tempdir: tempfile::TempDir,
+    keep_var: Option<OsString>,
+) -> MaybePermanentTempDir {
+    if keep_var == Some("1".into()) {
+        let tempdir = tempdir.into_path();
+        eprintln!("Keeping temporary directory: {}", tempdir.display());
+        MaybePermanentTempDir::Keep(tempdir)
+    } else {
+        MaybePermanentTempDir::Discard(tempdir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Test that the temporary directory is discarded by default.
+    #[rstest]
+    #[case::env_unset(None)]
+    #[case::env_set_to_0(Some("0".into()))]
+    #[case::env_set_to_false(Some("false".into()))]
+    #[case::env_set_to_no(Some("no".into()))]
+    #[case::env_set_to_off(Some("off".into()))]
+    #[case::env_set_to_true(Some("true".into()))]
+    #[case::env_set_to_yes(Some("yes".into()))]
+    #[case::env_set_to_on(Some("on".into()))]
+    fn test_discard_tempdir(#[case] env_var: Option<OsString>) {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let tmp_dir = maybe_keep_tempdir_impl(tmp_dir, env_var);
+        let tmp_path = tmp_dir.path().to_owned();
+
+        // Delete the temporary directory.
+        drop(tmp_dir);
+        assert!(!tmp_path.exists());
+    }
+
+    /// Test that the temporary directory can be kept.
+    #[test]
+    fn test_keep_tempdir() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let tmp_dir = maybe_keep_tempdir_impl(tmp_dir, Some("1".into()));
+        let tmp_path = tmp_dir.path().to_owned();
+
+        // Keep the temporary directory.
+        drop(tmp_dir);
+        assert!(tmp_path.is_dir());
+        std::fs::remove_dir_all(tmp_path).unwrap();
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -563,23 +563,24 @@ mod tests {
 
     #[test]
     fn test_create_config_from_invalid_ref() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let tmp_path = tmp_dir.path();
+        let tmp_path = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+            "git_toprepo-test_create_config_from_invalid_ref-",
+        );
         let env = commit_env_for_testing();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["init"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["config", GIT_CONFIG_KEY, "local:foobar.toml"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        let err: anyhow::Error = GitTopRepoConfig::load_config_from_repo(tmp_path).unwrap_err();
+        let err: anyhow::Error = GitTopRepoConfig::load_config_from_repo(&tmp_path).unwrap_err();
         assert_eq!(
             format!("{err:#}"),
             "Loading local:foobar.toml: Reading config file: No such file or directory (os error 2)"
@@ -590,11 +591,12 @@ mod tests {
     fn test_create_config_from_worktree() {
         use std::io::Write;
 
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let tmp_path = tmp_dir.path();
+        let tmp_path = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+            "git_toprepo-test_create_config_from_worktree-",
+        );
         let env = commit_env_for_testing();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["init"])
             .envs(&env)
             .check_success_with_stderr()
@@ -604,19 +606,19 @@ mod tests {
 
         writeln!(tmp_file, "{BAR_BAZ}").unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["add", "foobar.toml"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["config", GIT_CONFIG_KEY, "local:foobar.toml"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        let config = GitTopRepoConfig::load_config_from_repo(tmp_path).unwrap();
+        let config = GitTopRepoConfig::load_config_from_repo(&tmp_path).unwrap();
 
         let foo_name = SubRepoName::new("foo".to_owned());
         assert!(config.subrepos.contains_key(&foo_name));
@@ -642,30 +644,31 @@ mod tests {
 
     #[test]
     fn test_missing_config() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let tmp_path = tmp_dir.path();
+        let tmp_path = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+            "git_toprepo-test_missing_config-",
+        );
         let env = commit_env_for_testing();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["init"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["commit", "--allow-empty", "-m", "Initial commit"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["update-ref", "refs/namespaces/top/HEAD", "HEAD"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
         // Try a path in the repository.
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["config", GIT_CONFIG_KEY, "repo:HEAD:.gittoprepo.toml"])
             .check_success_with_stderr()
             .unwrap();
@@ -673,18 +676,18 @@ mod tests {
         assert_eq!(
             format!(
                 "{:#}",
-                GitTopRepoConfig::load_config_from_repo(tmp_path).unwrap_err()
+                GitTopRepoConfig::load_config_from_repo(&tmp_path).unwrap_err()
             ),
             "Loading repo:HEAD:.gittoprepo.toml: exit status: 128:\n\
             fatal: path '.gittoprepo.toml' does not exist in 'HEAD'\n"
         );
 
         // Try the worktree.
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["config", GIT_CONFIG_KEY, "local:nonexisting.toml"])
             .check_success_with_stderr()
             .unwrap();
-        let err = GitTopRepoConfig::load_config_from_repo(tmp_path).unwrap_err();
+        let err = GitTopRepoConfig::load_config_from_repo(&tmp_path).unwrap_err();
         assert_eq!(
             format!("{err:#}"),
             "Loading local:nonexisting.toml: Reading config file: No such file or directory (os error 2)"
@@ -722,11 +725,12 @@ mod tests {
         // TODO: Move to integration tests.
         use std::io::Write;
 
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let tmp_path = tmp_dir.path();
+        let tmp_path = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+            "git_toprepo-test_create_config_from_head-",
+        );
         let env = commit_env_for_testing();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["init"])
             .envs(&env)
             .check_success_with_stderr()
@@ -735,37 +739,37 @@ mod tests {
         let mut tmp_file = std::fs::File::create(tmp_path.join(".gittoprepo.toml")).unwrap();
         writeln!(tmp_file, "{BAR_BAZ}").unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["add", ".gittoprepo.toml"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["commit", "-m", "Initial commit"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["update-ref", "refs/namespaces/top/HEAD", "HEAD"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["rm", ".gittoprepo.toml"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args(["commit", "-m", "Remove .gittoprepo.toml"])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(tmp_path)
+        git_command(&tmp_path)
             .args([
                 "config",
                 GIT_CONFIG_KEY,
@@ -774,7 +778,7 @@ mod tests {
             .check_success_with_stderr()
             .unwrap();
 
-        let config = GitTopRepoConfig::load_config_from_repo(tmp_path).unwrap();
+        let config = GitTopRepoConfig::load_config_from_repo(&tmp_path).unwrap();
 
         let foo_name = SubRepoName::new("foo".to_owned());
         assert!(config.subrepos.contains_key(&foo_name));

--- a/src/git_fast_export_import.rs
+++ b/src/git_fast_export_import.rs
@@ -876,9 +876,10 @@ mod tests {
 
     #[test]
     fn test_parse_fast_export_output() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        // Debug with tmp_dir.into_path() which persists the directory.
-        let example_repo = setup_example_repo(tmp_dir.path());
+        let tmp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+            "git_toprepo_test_parse_fast_export_output",
+        );
+        let example_repo = setup_example_repo(&tmp_dir);
 
         let (log_accumulator, logger) =
             crate::log::tests::LogAccumulator::new(Arc::new(AtomicUsize::new(0)));
@@ -953,10 +954,12 @@ mod tests {
 
     #[test]
     fn test_fast_import() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+            "git_toprepo-test_fast_import-",
+        );
         let from_repo_path = setup_example_repo(&temp_dir.path().join("from"));
 
-        let to_repo_path = temp_dir.path().join("to");
+        let to_repo_path = temp_dir.join("to");
         std::fs::create_dir(&to_repo_path).unwrap();
         git_command(&to_repo_path)
             .args(["init"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -755,9 +755,9 @@ mod tests {
 
     #[test]
     fn test_main_outside_git_toprepo() {
-        let temp_dir = tempfile::TempDir::with_prefix("git-toprepo-").unwrap();
-        // Debug with &temp_dir.into_path() to persist the path.
-        let temp_dir = temp_dir.path();
+        let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+            "git_toprepo-test_main_outside_git_toprepo-",
+        );
         let temp_dir_str = temp_dir.to_str().unwrap();
         let argv = vec!["git-toprepo", "-C", temp_dir_str, "config", "show"];
         let argv = argv.into_iter().map(|s| s.into());

--- a/tests/integration/clone.rs
+++ b/tests/integration/clone.rs
@@ -9,10 +9,14 @@ use std::process::Command;
 
 #[test]
 fn test_toprepo_clone() {
-    let from_dir = tempfile::TempDir::with_prefix("git-toprepo-").unwrap();
+    let from_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+        "git_toprepo-test_toprepo_clone-from-",
+    );
     let from_path = from_dir.path();
 
-    let to_dir = tempfile::TempDir::with_prefix("git-toprepo-").unwrap();
+    let to_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+        "git_toprepo-test_toprepo_clone-to-",
+    );
     let to_path = to_dir.path();
     let env = HashMap::from([
         ("GIT_AUTHOR_NAME", "A Name"),

--- a/tests/integration/config.rs
+++ b/tests/integration/config.rs
@@ -15,9 +15,9 @@ const GENERIC_CONFIG: &str = r#"
 
 #[test]
 fn test_validate_external_file_in_corrupt_repository() {
-    let temp_dir = tempfile::TempDir::with_prefix("git-toprepo-").unwrap();
-    // Debug with &temp_dir.into_path() to persist the path.
-    let temp_dir = temp_dir.path();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+        "git_toprepo-test_validate_external_file_in_corrupt_repository-",
+    );
 
     // TODO: Set NO_COLOR here.
     let deterministic = commit_env_for_testing();
@@ -35,13 +35,13 @@ fn test_validate_external_file_in_corrupt_repository() {
     let okay_config = "okay.toml";
     std::fs::write(temp_dir.join(okay_config), GENERIC_CONFIG).unwrap();
 
-    git_command(temp_dir)
+    git_command(&temp_dir)
         .args(["init"])
         .envs(&deterministic)
         .check_success_with_stderr()
         .unwrap();
 
-    git_command(temp_dir)
+    git_command(&temp_dir)
         .args(["config", GIT_CONFIG_KEY, &format!("local:{invalid_toml}")])
         .envs(&deterministic)
         .check_success_with_stderr()
@@ -51,7 +51,7 @@ fn test_validate_external_file_in_corrupt_repository() {
 
     Command::cargo_bin("git-toprepo")
         .unwrap()
-        .current_dir(temp_dir)
+        .current_dir(&temp_dir)
         .arg("config")
         .arg("show")
         .assert()
@@ -65,7 +65,7 @@ fn test_validate_external_file_in_corrupt_repository() {
 
     Command::cargo_bin("git-toprepo")
         .unwrap()
-        .current_dir(temp_dir)
+        .current_dir(&temp_dir)
         .arg("config")
         .arg("validate")
         .arg(invalid_toml)
@@ -80,7 +80,7 @@ fn test_validate_external_file_in_corrupt_repository() {
 
     Command::cargo_bin("git-toprepo")
         .unwrap()
-        .current_dir(temp_dir)
+        .current_dir(&temp_dir)
         .arg("config")
         .arg("validate")
         .arg(incorrect_config)
@@ -95,7 +95,7 @@ fn test_validate_external_file_in_corrupt_repository() {
 
     Command::cargo_bin("git-toprepo")
         .unwrap()
-        .current_dir(temp_dir)
+        .current_dir(&temp_dir)
         .arg("config")
         .arg("validate")
         .arg(okay_config)
@@ -105,16 +105,16 @@ fn test_validate_external_file_in_corrupt_repository() {
 
 #[test]
 fn test_config_commands_use_correct_working_directory() {
-    let temp_dir = tempfile::TempDir::with_prefix("git-toprepo-").unwrap();
-    // Debug with &temp_dir.into_path() to persist the path.
-    let temp_dir = temp_dir.path();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+        "git_toprepo-test_config_commands_use_correct_working_directory-",
+    );
 
     let okay_config = "okay.toml";
     std::fs::write(temp_dir.join(okay_config), GENERIC_CONFIG).unwrap();
 
     Command::cargo_bin("git-toprepo")
         .unwrap()
-        .current_dir(temp_dir)
+        .current_dir(&temp_dir)
         .arg("config")
         .arg("validate")
         .arg(okay_config)
@@ -124,7 +124,7 @@ fn test_config_commands_use_correct_working_directory() {
     Command::cargo_bin("git-toprepo")
         .unwrap()
         .arg("-C")
-        .arg(temp_dir)
+        .arg(&temp_dir)
         .arg("config")
         .arg("validate")
         .arg(okay_config)
@@ -133,7 +133,7 @@ fn test_config_commands_use_correct_working_directory() {
 
     // Try to run from a subdirectory inside a git repo.
     Command::new("git")
-        .current_dir(temp_dir)
+        .current_dir(&temp_dir)
         .arg("init")
         .assert()
         .success();

--- a/tests/integration/dump.rs
+++ b/tests/integration/dump.rs
@@ -10,17 +10,15 @@ const GENERIC_CONFIG: &str = r#"
 
 #[test]
 fn test_dump_outside_git_repo() {
-    let temp_dir = tempfile::TempDir::with_prefix("git-toprepo-dump-").unwrap();
-    // Debug with &temp_dir.into_path() to persist the path.
-    // TODO: Parameterize all integrations tests to keep their temporary files.
-    // Possibly with an environment variable?
-    let temp_dir = temp_dir.path();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
+        "git_toprepo-test_dump_outside_git_repo-",
+    );
 
     std::fs::write(temp_dir.join(".gittoprepo.toml"), GENERIC_CONFIG).unwrap();
 
     Command::cargo_bin("git-toprepo")
         .unwrap()
-        .current_dir(temp_dir)
+        .current_dir(&temp_dir)
         // An arbitrary subcommand that requires it to be initialized
         .arg("dump")
         .arg("import-cache")

--- a/tests/integration/fetch.rs
+++ b/tests/integration/fetch.rs
@@ -114,26 +114,28 @@ fn test_fetch_only_needed_commits() {
         );
 }
 
+// TODO: Using #[allow(unused)] because the members will probably be used in the
+// near future.
 struct RepoWithTwoSubmodules {
-    // TODO: Using #[allow(unused)] because the members will probably be used in
-    // the near future.
-    #[allow(unused)]
-    temp_dir: tempfile::TempDir,
     pub toprepo: std::path::PathBuf,
     pub monorepo: std::path::PathBuf,
     #[allow(unused)]
     pub subx_repo: std::path::PathBuf,
     #[allow(unused)]
     pub suby_repo: std::path::PathBuf,
+
+    #[allow(unused)]
+    temp_dir: git_toprepo_testtools::test_util::MaybePermanentTempDir,
 }
 
 impl RepoWithTwoSubmodules {
     pub fn new_minimal_with_two_submodules() -> Self {
-        let temp_dir_guard = gix_testtools::scripted_fixture_writable(
-            "../integration/fixtures/make_minimal_with_two_submodules.sh",
-        )
-        .unwrap();
-        let temp_dir = temp_dir_guard.path().to_owned();
+        let temp_dir = git_toprepo_testtools::test_util::maybe_keep_tempdir(
+            gix_testtools::scripted_fixture_writable(
+                "../integration/fixtures/make_minimal_with_two_submodules.sh",
+            )
+            .unwrap(),
+        );
         let toprepo = temp_dir.join("top");
         let monorepo = temp_dir.join("mono");
         crate::fixtures::toprepo::clone(&toprepo, &monorepo);
@@ -156,11 +158,11 @@ impl RepoWithTwoSubmodules {
         std::fs::remove_dir_all(&suby_repo).unwrap();
 
         Self {
-            temp_dir: temp_dir_guard,
             toprepo,
             monorepo,
             subx_repo: temp_dir.join("subx"),
             suby_repo: temp_dir.join("suby"),
+            temp_dir,
         }
     }
 }

--- a/tests/integration/fixtures/toprepo.rs
+++ b/tests/integration/fixtures/toprepo.rs
@@ -20,16 +20,17 @@ use std::path::Path;
 /// # Examples
 ///
 /// ```rust
+/// // See [`git_toprepo_testtools::test_util::maybe_keep_tempdir`] how to set
+/// // the environment variable to persist the temporary directory.
 /// let tmp_path = readme_example_tempdir();
-/// // To persistent the directory, use:
-/// // let tmp_path = &tmp_dir.into_path();
-/// let tmp_path = tmp_dir.path();
 /// let top_repo_path = tmp_path.join("top");
 /// assert!(!top_repo_path.exists());
 /// ```
-pub fn readme_example_tempdir() -> tempfile::TempDir {
-    gix_testtools::scripted_fixture_writable("../integration/fixtures/make_readme_example.sh")
-        .unwrap()
+pub fn readme_example_tempdir() -> git_toprepo_testtools::test_util::MaybePermanentTempDir {
+    git_toprepo_testtools::test_util::maybe_keep_tempdir(
+        gix_testtools::scripted_fixture_writable("../integration/fixtures/make_readme_example.sh")
+            .unwrap(),
+    )
 }
 
 pub fn clone(toprepo: &Path, monorepo: &Path) {

--- a/tests/integration/push.rs
+++ b/tests/integration/push.rs
@@ -6,7 +6,6 @@ use std::process::Command;
 #[test]
 fn test_push_empty_commit_should_fail() {
     let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
-    let temp_dir = temp_dir.path();
     let toprepo = temp_dir.join("top");
     let monorepo = temp_dir.join("mono");
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
@@ -35,7 +34,6 @@ fn test_push_empty_commit_should_fail() {
 #[test]
 fn test_push_top() {
     let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
-    let temp_dir = temp_dir.path();
     let toprepo = temp_dir.join("top");
     let monorepo = temp_dir.join("mono");
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
@@ -76,7 +74,6 @@ fn test_push_top() {
 #[test]
 fn test_push_submodule() {
     let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
-    let temp_dir = &temp_dir.into_path();
     let toprepo = temp_dir.join("top");
     let monorepo = temp_dir.join("mono");
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
@@ -117,7 +114,6 @@ fn test_push_submodule() {
 #[test]
 fn test_push_revision() {
     let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
-    let temp_dir = temp_dir.path();
     let toprepo = temp_dir.join("top");
     let monorepo = temp_dir.join("mono");
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
@@ -161,7 +157,6 @@ fn test_push_revision() {
 #[test]
 fn test_push_from_sub_directory() {
     let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
-    let temp_dir = temp_dir.path();
     let toprepo = temp_dir.join("top");
     let monorepo = temp_dir.join("mono");
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);


### PR DESCRIPTION
This also adds a new git-toprepo-testtools crate to share test code.