### PR TITLE
Implement parallel push and test topic push

### DIFF
--- a/src/push.rs
+++ b/src/push.rs
@@ -8,6 +8,8 @@ use crate::git_fast_export_import::FastImportCommit;
 use crate::git_fast_export_import::ImportCommitRef;
 use crate::gitmodules::SubmoduleUrlExt as _;
 use crate::log::CommandSpanExt as _;
+use crate::log::InterruptedError;
+use crate::log::InterruptedResult;
 use crate::repo::ExpandedOrRemovedSubmodule;
 use crate::repo::ExpandedSubmodule;
 use crate::repo::MonoRepoCommit;
@@ -17,8 +19,10 @@ use crate::repo::MonoRepoProcessor;
 use crate::repo::SubmoduleContent;
 use crate::repo::TopRepoCommitId;
 use crate::repo_name::RepoName;
-use crate::util::CommandExtension as _;
+use crate::ui::ProgressStatus;
+use crate::ui::ProgressTaskHandle;
 use crate::util::EMPTY_GIX_URL;
+use crate::util::SafeExitStatus;
 use anyhow::Context;
 use anyhow::Result;
 use bstr::ByteSlice as _;
@@ -27,6 +31,101 @@ use gix::refs::FullNameRef;
 use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+pub fn split_for_push(
+    processor: &mut MonoRepoProcessor,
+    top_push_url: &gix::Url,
+    local_rev_or_ref: &String,
+) -> Result<Vec<PushMetadata>> {
+    if processor.top_repo_cache.monorepo_commits.is_empty() {
+        anyhow::bail!("No filtered mono commits exists, please run `git toprepo refilter` first");
+    }
+    let repo = processor.gix_repo.to_thread_local();
+
+    let local_rev = repo.rev_parse_single(local_rev_or_ref.as_bytes())?;
+    let local_rev_arg: std::ffi::OsString = local_rev.to_hex().to_string().into();
+    let export_refs_args: Vec<std::ffi::OsString> = repo
+        .references()?
+        .prefixed(b"refs/remotes/origin/".as_bstr())?
+        .map(|r| {
+            let r = match r {
+                Ok(r) => r,
+                Err(err) => anyhow::bail!("{err:#}"),
+            }
+            .detach();
+            match bstr::concat([b"^".as_bstr(), r.name.as_bstr()]).to_os_str() {
+                Ok(arg) => Ok(arg.to_owned()),
+                Err(err) => anyhow::bail!("{err:#}"),
+            }
+        })
+        .chain([Ok(local_rev_arg)])
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| "Failed while iterating refs/remotes/origin/")?;
+
+    let mut dedup_cache = std::mem::take(&mut processor.top_repo_cache.dedup);
+    let mut fast_importer = crate::git_fast_export_import_dedup::FastImportRepoDedup::new(
+        crate::git_fast_export_import::FastImportRepo::new(processor.gix_repo.git_dir())?,
+        &mut dedup_cache,
+    );
+    let to_push_metadata = split_for_push_impl(
+        processor,
+        &mut fast_importer,
+        top_push_url,
+        &export_refs_args,
+    );
+    // Make sure to gracefully shutdown the fast-importer before returning.
+    fast_importer.wait()?;
+    processor.top_repo_cache.dedup = dedup_cache;
+
+    to_push_metadata
+}
+
+/// Redundant pushes are pushes that can be part of a descendant commit. For
+/// example, the topic feature in Gerrit requires a git-push parameter `-o
+/// topic=` for the commit that should get the topic which means that all
+/// parents will get the same topic if uploaded in the same git-push command.
+///
+/// This function removes redundant pushes from the `push_metadata` vector, so
+/// that only the last push for each command line is kept.
+///
+/// The implementation assumes that the `push_metadata` is topologically sorted,
+/// i.e. parents are before descendants. Each remaining entry needs to be pushed
+/// before the following entries.
+pub fn remove_redundant_pushes(push_metadata: &mut Vec<PushMetadata>) {
+    // Go through the children before the parents. The branch tips need to be
+    // pushed, the question is if their parents have the same parameters and can
+    // be skipped.
+    push_metadata.reverse();
+    // redundant_pushes maps a push parameters that would make the git-push redundant, because a child would then do the job.to parameters that are not sent over with each individual commit,
+    // for example the `-o topic=` when pushing to Gerrit.
+    let mut redundant_pushes = HashMap::new();
+    push_metadata.retain(|push_info| {
+        // A---B---E
+        //  \     /
+        //   C'--D'
+        // E is needed, D' is needed, C' is not. Either A or B is needed, but
+        // not both because it depends if B is pushed before C' or not. If B and
+        // C' are pushed parallelly, then A is needed. Now, it is generally not
+        // possible to push to the same ref in parallel. Therefore, we can
+        // assume that B is pushed before C', so A is not needed.
+        let extra_args = push_info.extra_args();
+        let is_needed = redundant_pushes
+            .remove(&(push_info.push_url.clone(), push_info.commit_id))
+            .as_ref()
+            != Some(&extra_args);
+        for parent in &push_info.parents {
+            // Even if the entry exists, it should be replaced to show that the
+            // first push after `*parent` will be with `extra_args`. Later
+            // pushes will not affect anything anyway.
+            redundant_pushes.insert((push_info.push_url.clone(), *parent), extra_args.clone());
+        }
+        is_needed
+    });
+    push_metadata.reverse();
+}
 
 fn rewrite_push_message(message: &str) -> (String, Option<String>) {
     let mut filtered_message = String::with_capacity(message.len());
@@ -41,10 +140,17 @@ fn rewrite_push_message(message: &str) -> (String, Option<String>) {
             filtered_message.push('\n');
         }
     }
+    // If the original message was "Subject\n\nTopic: something\n", the double
+    // LF should be removed.
+    while filtered_message.ends_with("\n\n") {
+        filtered_message.pop();
+    }
     (filtered_message, topic)
 }
 
-/// Resolves which repository to push to. Note that the push URL might not be part of the git-toprepo configuration, so `url` is used when resolving the that.
+/// Resolves which repository to push to. Note that the push URL might not be
+/// part of the git-toprepo configuration, so `push_url` is used as base when
+/// resolving the destinations.
 fn resolve_push_repo(
     mono_commit: &gix::Commit,
     path: GitPath,
@@ -107,19 +213,16 @@ fn resolve_push_repo(
     }
 }
 
-fn split_for_push(
-    gix_repo: &gix::ThreadSafeRepository,
-    progress: &indicatif::MultiProgress,
-    top_repo_cache: &crate::repo::TopRepoCache,
-    config: &mut crate::config::GitTopRepoConfig,
+fn split_for_push_impl(
+    processor: &mut MonoRepoProcessor,
     fast_importer: &mut crate::git_fast_export_import_dedup::FastImportRepoDedup<'_>,
     top_push_url: &gix::Url,
     export_refs_args: &[std::ffi::OsString],
 ) -> Result<Vec<PushMetadata>> {
-    let monorepo_commits = &top_repo_cache.monorepo_commits;
-    let repo = gix_repo.to_thread_local();
+    let monorepo_commits = &processor.top_repo_cache.monorepo_commits;
+    let repo = processor.gix_repo.to_thread_local();
 
-    let pb = progress.add(
+    let pb = processor.progress.add(
         indicatif::ProgressBar::no_length()
             .with_style(
                 indicatif::ProgressStyle::default_spinner()
@@ -129,7 +232,7 @@ fn split_for_push(
             .with_message("Splitting commits"),
     );
     let fast_exporter = crate::git_fast_export_import::FastExportRepo::load_from_path(
-        gix_repo.git_dir(),
+        processor.gix_repo.git_dir(),
         Some(export_refs_args),
     )?;
 
@@ -176,7 +279,7 @@ fn split_for_push(
                         &gix_mono_commit,
                         GitPath::new(fc.path),
                         top_push_url.clone(),
-                        config,
+                        &mut processor.config,
                     )?;
                     grouped_file_changes
                         .entry((submod_path, repo_name, push_url))
@@ -190,7 +293,7 @@ fn split_for_push(
                 if grouped_file_changes.len() > 1 && topic.is_none() {
                     anyhow::bail!(
                         "Multiple submodules changed in commit {mono_commit_id}, but no topic was provided. \
-                            Please amend the commit message to add a 'Topic: something-descriptive' line."
+                        Please amend the commit message to add a 'Topic: something-descriptive' line."
                     );
                 }
                 for ((abs_sub_path, repo_name, push_url), file_changes) in grouped_file_changes {
@@ -240,7 +343,7 @@ fn split_for_push(
                     let import_commit_id = fast_importer.get_object_id(&import_ref)?;
                     imported_submod_commits.insert(import_commit_id, import_ref);
 
-                    let (top_bump, submodule_bumps) = match repo_name {
+                    let (top_bump, submodule_bumps) = match &repo_name {
                         RepoName::Top => {
                             (Some(TopRepoCommitId::new(import_commit_id)), HashMap::new())
                         }
@@ -250,7 +353,7 @@ fn split_for_push(
                                 abs_sub_path,
                                 ExpandedOrRemovedSubmodule::Expanded(ExpandedSubmodule::Expanded(
                                     SubmoduleContent {
-                                        repo_name: sub_repo_name,
+                                        repo_name: sub_repo_name.clone(),
                                         orig_commit_id: import_commit_id,
                                     },
                                 )),
@@ -268,6 +371,7 @@ fn split_for_push(
                     imported_mono_commits
                         .insert(exported_mono_commit.original_id, mono_commit.clone());
                     to_push_metadata.push(PushMetadata {
+                        repo_name,
                         push_url,
                         topic: topic.clone(),
                         commit_id: import_commit_id,
@@ -288,139 +392,262 @@ fn split_for_push(
     Ok(to_push_metadata)
 }
 
-pub struct PushProcessor<'a>(&'a mut MonoRepoProcessor);
+#[derive(Debug, Clone)]
+pub struct PushMetadata {
+    pub repo_name: RepoName,
+    pub push_url: gix::Url,
+    pub topic: Option<String>,
+    pub commit_id: CommitId,
+    pub parents: Vec<CommitId>,
+}
 
-impl<'a> PushProcessor<'a> {
-    pub fn new(processor: &'a mut MonoRepoProcessor) -> Self {
-        Self(processor)
+impl PushMetadata {
+    /// Returns extra parameters for the git-push command.
+    pub fn extra_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(topic) = &self.topic {
+            args.push("-o".to_owned());
+            args.push(format!("topic={topic}"));
+        }
+        args
+    }
+}
+
+pub struct CommitPusher {
+    context: PushContext,
+    thread_count: NonZeroUsize,
+}
+
+impl CommitPusher {
+    pub fn new(
+        toprepo: gix::ThreadSafeRepository,
+        progress: indicatif::MultiProgress,
+        error_observer: crate::log::ErrorObserver,
+        thread_count: NonZeroUsize,
+    ) -> Self {
+        let summary_pb = indicatif::ProgressBar::no_length()
+            .with_style(
+                indicatif::ProgressStyle::with_template(
+                    "{elapsed:>4} {prefix:.cyan} [{bar:24}] {pos}/{len}{wide_msg}",
+                )
+                .unwrap()
+                .progress_chars("=> "),
+            )
+            .with_prefix("Pushing");
+        // Make sure that the elapsed time is updated continuously.
+        summary_pb.enable_steady_tick(std::time::Duration::from_millis(1000));
+        let push_progress = ProgressStatus::new(progress.clone(), progress.add(summary_pb));
+        Self {
+            context: PushContext {
+                toprepo,
+                push_progress,
+                error_observer: Arc::new(Mutex::new(error_observer)),
+            },
+            thread_count,
+        }
     }
 
     pub fn push(
-        &mut self,
-        top_push_url: &gix::Url,
-        local_rev_or_ref: &String,
+        &self,
+        push_metadata: Vec<PushMetadata>,
         remote_ref: &FullName,
         dry_run: bool,
     ) -> Result<()> {
-        if self.0.top_repo_cache.monorepo_commits.is_empty() {
-            anyhow::bail!(
-                "No filtered mono commits exists, please run `git toprepo refilter` first"
-            );
-        }
-        let repo = self.0.gix_repo.to_thread_local();
-
-        let local_rev = repo.rev_parse_single(local_rev_or_ref.as_bytes())?;
-        let local_rev_arg: std::ffi::OsString = local_rev.to_hex().to_string().into();
-        let export_refs_args: Vec<std::ffi::OsString> = repo
-            .references()?
-            .prefixed(b"refs/remotes/origin/".as_bstr())?
-            .map(|r| {
-                let r = match r {
-                    Ok(r) => r,
-                    Err(err) => anyhow::bail!("{err:#}"),
-                }
-                .detach();
-                match bstr::concat([b"^".as_bstr(), r.name.as_bstr()]).to_os_str() {
-                    Ok(arg) => Ok(arg.to_owned()),
-                    Err(err) => anyhow::bail!("{err:#}"),
-                }
-            })
-            .chain([Ok(local_rev_arg)])
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .with_context(|| "Failed while iterating refs/remotes/origin/")?;
-
-        let mut dedup_cache = std::mem::take(&mut self.0.top_repo_cache.dedup);
-        let mut fast_importer = crate::git_fast_export_import_dedup::FastImportRepoDedup::new(
-            crate::git_fast_export_import::FastImportRepo::new(self.0.gix_repo.git_dir())?,
-            &mut dedup_cache,
-        );
-        let to_push_metadata = split_for_push(
-            &self.0.gix_repo,
-            &self.0.progress,
-            &self.0.top_repo_cache,
-            &mut self.0.config,
-            &mut fast_importer,
-            top_push_url,
-            &export_refs_args,
-        );
-        // Make sure to gracefully shutdown the fast-importer before returning.
-        fast_importer.wait()?;
-        self.0.top_repo_cache.dedup = dedup_cache;
-        let mut to_push_metadata = to_push_metadata?;
-
-        // Group the pushes together to run fewer git-push commands.
-        to_push_metadata.reverse();
-        let mut redundant_pushes = HashMap::new();
-        to_push_metadata.retain(|push_info| {
-            let is_needed = redundant_pushes
-                .remove(&(push_info.push_url.clone(), push_info.commit_id))
-                .as_ref()
-                != Some(&push_info.topic);
-            for parent in &push_info.parents {
-                // Even if the entry exists, it should be replaced to show that
-                // the first push after `*parent` will be with `topic`. Later
-                // pushes will not affect anything anyway.
-                redundant_pushes.insert(
-                    (push_info.push_url.clone(), *parent),
-                    push_info.topic.clone(),
-                );
-            }
-            is_needed
-        });
-        to_push_metadata.reverse();
-        if to_push_metadata.is_empty() {
+        if push_metadata.is_empty() {
             log::info!("Nothing to push");
             return Ok(());
         }
+        self.push_to_remote_parallel(push_metadata, remote_ref, dry_run);
+        self.context
+            .error_observer
+            .lock()
+            .unwrap()
+            .get_result(())
+            .context("Some git-push commands failed, see the logs for details")
+    }
 
-        let info_label = if dry_run { "Would run" } else { "Running" };
-        let mut failed_pushes = 0;
-        for push_info in to_push_metadata {
-            let topic_arg = match &push_info.topic {
-                Some(topic) => format!(" -o topic={topic}"),
-                None => String::new(),
-            };
-            log::info!(
-                "{info_label}: git push {}{topic_arg} {}:{remote_ref}",
-                push_info.push_url,
-                push_info.commit_id.to_hex()
-            );
-            if dry_run {
-                continue;
-            }
-            // Do the push.
-            let mut cmd = git_command(self.0.gix_repo.git_dir());
-            cmd.arg("push")
-                .arg(push_info.push_url.to_bstring().to_os_str()?);
-            if let Some(topic) = &push_info.topic {
-                cmd.arg("-o").arg(format!("topic={topic}"));
-            }
-            cmd.arg(format!("{}:{remote_ref}", push_info.commit_id));
-            if let Err(err) = cmd
-                .trace_command(crate::command_span!("git push"))
-                .safe_status()?
-                .check_success()
-            {
-                log::info!(
-                    "Failed to git push {} {}:{remote_ref}: {err:#}",
-                    push_info.push_url,
-                    push_info.commit_id
-                );
-                failed_pushes += 1;
-            }
+    fn push_to_remote_parallel(
+        &self,
+        push_metadata: Vec<PushMetadata>,
+        remote_ref: &FullName,
+        dry_run: bool,
+    ) {
+        let splitted_metadata = push_metadata
+            .into_iter()
+            .into_group_map_by(|info| info.push_url.clone());
+        let thread_pool = threadpool::ThreadPool::new(std::cmp::min(
+            self.thread_count.get(),
+            splitted_metadata.len(),
+        ));
+        // Make push order deterministic.
+        let mut sorted_metadata = splitted_metadata.into_iter().collect::<Vec<_>>();
+        sorted_metadata.sort_by_key(|(push_url, _)| push_url.clone());
+        for (_push_url, url_push_metadata) in sorted_metadata {
+            let mut task = PushTask::new(self.context.clone(), url_push_metadata);
+            let remote_ref = remote_ref.clone();
+            let error_observer = self.context.error_observer.clone();
+            thread_pool.execute(move || {
+                let result = task.push_all(&remote_ref, dry_run);
+                error_observer.lock().unwrap().consume_interrupted(result);
+            });
         }
-        if failed_pushes != 0 {
-            let times_string = if failed_pushes == 1 { "time" } else { "times" };
-            anyhow::bail!(format!("git-push failed {failed_pushes} {times_string}"));
+        thread_pool.join();
+    }
+}
+
+#[derive(Clone)]
+struct PushContext {
+    toprepo: gix::ThreadSafeRepository,
+
+    push_progress: ProgressStatus,
+    /// Signal to not start new work but to fail as fast as possible.
+    error_observer: Arc<Mutex<crate::log::ErrorObserver>>,
+}
+
+struct PushTask {
+    context: PushContext,
+    /// Stuff to push in reverse order, i.e. the last item is pushed first by
+    /// using `reversed_push_metadata.pop()`.
+    reversed_push_metadata: Vec<PushMetadata>,
+
+    /// The currently active PushMetadata, if any.
+    current_push_item: Option<CurrentPushItem>,
+}
+
+struct CurrentPushItem {
+    repo_name: RepoName,
+    pb_url: indicatif::ProgressBar,
+    pb_status: indicatif::ProgressBar,
+
+    /// Keep a handle to the progress task to keep it visible in the UI.
+    #[allow(unused)]
+    progress_task: ProgressTaskHandle,
+}
+
+impl PushTask {
+    pub fn new(context: PushContext, mut push_metadata: Vec<PushMetadata>) -> Self {
+        context
+            .push_progress
+            .inc_queue_size(push_metadata.len() as isize);
+        push_metadata.reverse();
+        Self {
+            context,
+            reversed_push_metadata: push_metadata,
+            current_push_item: None,
+        }
+    }
+
+    pub fn push_all(&mut self, remote_ref: &FullName, dry_run: bool) -> InterruptedResult<()> {
+        while let Some(push_info) = self.reversed_push_metadata.pop() {
+            self.context.push_progress.inc_queue_size(-1);
+            if self
+                .context
+                .error_observer
+                .lock()
+                .unwrap()
+                .should_interrupt()
+            {
+                return Err(InterruptedError::Interrupted);
+            }
+            self.push_one(push_info, remote_ref, dry_run)?;
+        }
+        Ok(())
+    }
+
+    fn push_one(
+        &mut self,
+        push_info: PushMetadata,
+        remote_ref: &FullName,
+        dry_run: bool,
+    ) -> Result<()> {
+        // Update progress bars.
+        if self
+            .current_push_item
+            .as_ref()
+            .is_none_or(|item| item.repo_name != push_info.repo_name)
+        {
+            // Recreate the progress bar as this push is to a different repository.
+            self.current_push_item = None;
+            let pb_url = indicatif::ProgressBar::hidden()
+                .with_style(
+                    indicatif::ProgressStyle::with_template("     {prefix:.cyan} {msg}").unwrap(),
+                )
+                .with_prefix("git push");
+            let pb_status = indicatif::ProgressBar::hidden()
+                .with_style(indicatif::ProgressStyle::with_template("     {msg}").unwrap());
+            let progress_task = self.context.push_progress.start(
+                push_info.repo_name.to_string(),
+                vec![pb_url.clone(), pb_status.clone()],
+            );
+            self.current_push_item = Some(CurrentPushItem {
+                repo_name: push_info.repo_name.clone(),
+                pb_url,
+                pb_status,
+                progress_task,
+            });
+        }
+        let current_push_item = self.current_push_item.as_ref().expect("just set above");
+        current_push_item
+            .pb_url
+            .set_message(push_info.push_url.to_string());
+        // Log.
+        let extra_args = push_info.extra_args();
+        let log_command = format!(
+            "git push {}{} {}:{remote_ref}",
+            push_info.push_url,
+            extra_args.iter().map(|arg| format!(" {arg}")).join(""),
+            push_info.commit_id.to_hex()
+        );
+        log::info!(
+            "{} {log_command}",
+            if dry_run { "Would run" } else { "Running" },
+        );
+        // Run the command.
+        if !dry_run {
+            let (mut proc, _span_guard) = git_command(self.context.toprepo.git_dir())
+                .arg("push")
+                .arg(push_info.push_url.to_bstring().to_os_str()?)
+                .args(&extra_args)
+                .arg(format!("{}:{remote_ref}", push_info.commit_id))
+                // TODO: Collect stdout (use a thread to avoid backpressure deadlock).
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped())
+                .trace_command(crate::command_span!("git push"))
+                .spawn()
+                .with_context(|| "Failed to spawn git-push".to_string())?;
+            let permanent_stderr = crate::util::read_stderr_progress_status(
+                proc.stderr.take().expect("piping stderr"),
+                |line| current_push_item.pb_status.set_message(line),
+            );
+            let trimmed_stderr = permanent_stderr.trim_end();
+            let push_result =
+                SafeExitStatus::new(proc.wait().context("Failed to wait for git-push")?)
+                    .check_success()
+                    .map_err(|err| {
+                        let maybe_newline = if trimmed_stderr.is_empty() { "" } else { "\n" };
+                        anyhow::anyhow!(
+                            "Failed to {log_command}: {err:#}{maybe_newline}{trimmed_stderr}"
+                        )
+                    })
+                    .map(|_| ());
+            if push_result.is_ok() && !trimmed_stderr.is_empty() {
+                log::info!("Stderr from {log_command}\n{trimmed_stderr}");
+            }
+            self.context
+                .error_observer
+                .lock()
+                .unwrap()
+                .maybe_consume(push_result)?;
         }
         Ok(())
     }
 }
 
-#[derive(Debug, Clone)]
-struct PushMetadata {
-    pub push_url: gix::Url,
-    pub topic: Option<String>,
-    pub commit_id: CommitId,
-    pub parents: Vec<CommitId>,
+impl Drop for PushTask {
+    fn drop(&mut self) {
+        self.context
+            .push_progress
+            .inc_queue_size(-(self.reversed_push_metadata.len() as isize));
+        drop(self.current_push_item.take());
+    }
 }


### PR DESCRIPTION
Each repository has its own thread when pushing. If commits in the same repository need different push options, one could resolve parent-child relationships and push with even more parallelism, but that is left for the future if really needed.