### PR TITLE
Integration test config-bootstrap procedure

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,6 +141,9 @@ pub struct Clone {
     #[command(flatten)]
     pub init: Init,
 
+    #[command(flatten)]
+    pub refilter: Refilter,
+
     /// After fetching the top repository, skip fetching the submodules.
     #[clap(long)]
     pub minimal: bool,
@@ -514,6 +517,10 @@ pub struct Push {
     /// Stop pushing on the first error.
     #[arg(long)]
     pub fail_fast: bool,
+
+    /// Number of concurrent threads to load the repository.
+    #[arg(long, default_value = "7")]
+    pub jobs: std::num::NonZero<u16>,
 
     /// A configured git remote in the mono repository or a URL of the top
     /// repository to push to. Submodules are calculated relative this remote.

--- a/src/config.rs
+++ b/src/config.rs
@@ -686,12 +686,6 @@ mod tests {
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(&tmp_path)
-            .args(["update-ref", "refs/namespaces/top/HEAD", "HEAD"])
-            .envs(&env)
-            .check_success_with_stderr()
-            .unwrap();
-
         // Try a path in the repository.
         git_command(&tmp_path)
             .args(["config", GIT_CONFIG_KEY, "repo:HEAD:.gittoprepo.toml"])
@@ -777,7 +771,11 @@ mod tests {
             .unwrap();
 
         git_command(&tmp_path)
-            .args(["update-ref", "refs/namespaces/top/HEAD", "HEAD"])
+            .args([
+                "update-ref",
+                "refs/namespaces/top/refs/remotes/origin/HEAD",
+                "HEAD",
+            ])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
@@ -798,7 +796,7 @@ mod tests {
             .args([
                 "config",
                 GIT_CONFIG_KEY,
-                "repo:refs/namespaces/top/HEAD:.gittoprepo.toml",
+                "repo:refs/namespaces/top/refs/remotes/origin/HEAD:.gittoprepo.toml",
             ])
             .check_success_with_stderr()
             .unwrap();

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -71,6 +71,7 @@ pub struct CommitLoader<'a> {
     fetch_progress: ProgressStatus,
     /// Signal to not start new work but to fail as fast as possible.
     error_observer: crate::log::ErrorObserver,
+    pub log_missing_config_warnings: bool,
 
     thread_pool: threadpool::ThreadPool,
     ongoing_jobs_in_threads: usize,
@@ -141,6 +142,7 @@ impl<'a> CommitLoader<'a> {
             load_progress,
             fetch_progress,
             error_observer,
+            log_missing_config_warnings: true,
             thread_pool,
             ongoing_jobs_in_threads: 0,
             load_after_fetch: true,
@@ -683,6 +685,7 @@ impl<'a> CommitLoader<'a> {
             tree_id,
             self.config,
             &mut self.dot_gitmodules_cache,
+            self.log_missing_config_warnings,
         )
         .context(context)
         .map_err(InterruptedError::Normal)?;
@@ -849,6 +852,7 @@ impl<'a> CommitLoader<'a> {
         tree_id: TreeId,
         config: &mut GitTopRepoConfig,
         dot_gitmodules_cache: &mut DotGitModulesCache,
+        log_missing_config_warnings: bool,
     ) -> Result<(Rc<ThinCommit>, Vec<NeededCommit>)> {
         let commit_id: CommitId = exported_commit.original_id;
         let thin_parents = exported_commit
@@ -895,7 +899,7 @@ impl<'a> CommitLoader<'a> {
                             &repo_storage.url,
                             config,
                             dot_gitmodules_cache,
-                            true,
+                            log_missing_config_warnings,
                         );
                         if let Some(submod_repo_name) = &submod_repo_name {
                             new_submodule_commits.push(NeededCommit {
@@ -953,7 +957,7 @@ impl<'a> CommitLoader<'a> {
                             &repo_storage.url,
                             config,
                             dot_gitmodules_cache,
-                            true,
+                            log_missing_config_warnings,
                         );
                         if new_repo_name != thin_submod.repo_name {
                             // Insert an entry that this submodule has been updated.


### PR DESCRIPTION
This fixes the initial cloning and bootstrapping scenario, setting the correct .gittoprepo.toml ref in the git-config. An integration test running `git-toprepo clone` followed by `git-toprepo config bootstrap` is verifying that procedure.