### PR TITLE
Move .gitmodules mode error from git-fast-export to loader

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1385,6 +1385,17 @@ pub struct ThinSubmoduleContent {
     pub commit_id: CommitId,
 }
 
+/// A file entry received from git-fast-export pointing to a specific blob.
+#[serde_as]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ExportedFileEntry {
+    /// The mode reported by git-fast-export.
+    #[serde_as(as = "crate::util::SerdeOctalNumber")]
+    pub mode: u32,
+    #[serde_as(as = "serde_with::IfIsHumanReadable<serde_with::DisplayFromStr>")]
+    pub id: BlobId,
+}
+
 #[derive(Debug)]
 pub struct ThinCommit {
     pub commit_id: CommitId,
@@ -1393,7 +1404,7 @@ pub struct ThinCommit {
     /// strictly decreasing when following the parents.
     pub depth: u32,
     pub parents: Vec<Rc<ThinCommit>>,
-    pub dot_gitmodules: Option<BlobId>,
+    pub dot_gitmodules: Option<ExportedFileEntry>,
     /// Submodule updates in this commit compared to first parent. Added
     /// submodules are included. `BTreeMap` is used for deterministic ordering.
     pub submodule_bumps: BTreeMap<GitPath, ThinSubmodule>,
@@ -1411,7 +1422,7 @@ impl ThinCommit {
         commit_id: CommitId,
         tree_id: TreeId,
         parents: Vec<Rc<ThinCommit>>,
-        dot_gitmodules: Option<BlobId>,
+        dot_gitmodules: Option<ExportedFileEntry>,
         submodule_bumps: BTreeMap<GitPath, ThinSubmodule>,
     ) -> Rc<Self> {
         // Adding and removing more than one submodule at a time is so rare that

--- a/src/repo_cache_serde.rs
+++ b/src/repo_cache_serde.rs
@@ -1,10 +1,10 @@
-use crate::git::BlobId;
 use crate::git::CommitId;
 use crate::git::GitPath;
 use crate::git::TreeId;
 use crate::git_fast_export_import::WithoutCommitterId;
 use crate::git_fast_export_import_dedup::GitFastExportImportDedupCache;
 use crate::repo::ExpandedOrRemovedSubmodule;
+use crate::repo::ExportedFileEntry;
 use crate::repo::MonoRepoCommit;
 use crate::repo::MonoRepoCommitId;
 use crate::repo::MonoRepoParent;
@@ -49,7 +49,7 @@ pub struct SerdeTopRepoCache {
 
 impl SerdeTopRepoCache {
     const TOPREPO_CACHE_PATH: &str = "toprepo/cache.bincode";
-    const CACHE_VERSION_PRELUDE: &str = "#cache-format-v1\n";
+    const CACHE_VERSION_PRELUDE: &str = "#cache-format-v2\n";
 
     /// Constructs the path to the git repository information cache inside
     /// `.git/toprepo/`.
@@ -292,8 +292,7 @@ struct SerdeThinCommit {
     pub tree_id: TreeId,
     #[serde_as(as = "serde_with::IfIsHumanReadable<Vec<serde_with::DisplayFromStr>>")]
     pub parents: Vec<CommitId>,
-    #[serde_as(as = "serde_with::IfIsHumanReadable<Option<serde_with::DisplayFromStr>>")]
-    pub dot_gitmodules: Option<BlobId>,
+    pub dot_gitmodules: Option<ExportedFileEntry>,
     pub submodule_bumps: BTreeMap<GitPath, ThinSubmodule>,
 }
 


### PR DESCRIPTION
By moving the error, it is possible to check if the error is fixable at a specific revision, e.g. a tip of a branch. In git-fast-export, it is only available when it is changing and cannot be checked at an arbritrary revision.

This prepares for hiding unfixable warnings.