### PR TITLE
Config: use the shared git-toprepo namespace in git-config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,22 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-pub const TOPREPO_CONFIG_FILE_KEY: &str = "toprepo.config";
+// NB: We can't seem to curry this into a const function
+// https://docs.rs/const-str/latest/const_str/index.html#const-context-only
+// So we can either use a single variable for the full string
+// and type in the namespace (no compile-time concatenation),
+// or use a runtime function that just takes the key,
+// which should too be a constant.
+// So we can use either of the two use patterns:
+//    * `TOPREPO_CONFIG_FILE_KEY`
+//      benefits: tersest use sites
+//    * `toprepo_config(CONFIG_FILE_KEY)`
+//      benefits: does not repeat the namespace in multiple constant definitions.
+pub const TOPREPO_CONFIG_NAMESPACE: &str = "toprepo";
+pub fn toprepo_git_config(key: &str) -> String {
+    format!("{TOPREPO_CONFIG_NAMESPACE}.{key}")
+}
+pub const TOPREPO_CONFIG_FILE_KEY: &str = "config";
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
@@ -298,8 +313,9 @@ impl GitTopRepoConfig {
     pub fn find_configuration_location(repo_dir: &Path) -> Result<ConfigLocation> {
         // Load config file location.
 
-        let location = git_config_get(repo_dir, TOPREPO_CONFIG_FILE_KEY)?.with_context(|| {
-            format!("git-config '{TOPREPO_CONFIG_FILE_KEY}' is missing. Is this an initialized git-toprepo?")
+        let key = &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY);
+        let location = git_config_get(repo_dir, key)?.with_context(|| {
+            format!("git-config '{key}' is missing. Is this an initialized git-toprepo?")
         })?;
 
         ConfigLocation::from_str(&location)
@@ -631,7 +647,11 @@ mod tests {
             .unwrap();
 
         git_command(&tmp_path)
-            .args(["config", TOPREPO_CONFIG_FILE_KEY, "worktree:foobar.toml"])
+            .args([
+                "config",
+                &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
+                "worktree:foobar.toml",
+            ])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
@@ -669,7 +689,11 @@ mod tests {
             .unwrap();
 
         git_command(&tmp_path)
-            .args(["config", TOPREPO_CONFIG_FILE_KEY, "worktree:foobar.toml"])
+            .args([
+                "config",
+                &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
+                "worktree:foobar.toml",
+            ])
             .envs(&env)
             .check_success_with_stderr()
             .unwrap();
@@ -721,7 +745,7 @@ mod tests {
         git_command(&tmp_path)
             .args([
                 "config",
-                TOPREPO_CONFIG_FILE_KEY,
+                &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
                 "repo:HEAD:.gittoprepo.toml",
             ])
             .check_success_with_stderr()
@@ -740,7 +764,7 @@ mod tests {
         git_command(&tmp_path)
             .args([
                 "config",
-                TOPREPO_CONFIG_FILE_KEY,
+                &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
                 "worktree:nonexisting.toml",
             ])
             .check_success_with_stderr()
@@ -834,7 +858,7 @@ mod tests {
         git_command(&tmp_path)
             .args([
                 "config",
-                TOPREPO_CONFIG_FILE_KEY,
+                &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
                 "repo:refs/namespaces/top/refs/remotes/origin/HEAD:.gittoprepo.toml",
             ])
             .check_success_with_stderr()

--- a/src/main.rs
+++ b/src/main.rs
@@ -841,6 +841,8 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::TOPREPO_CONFIG_FILE_KEY;
+    use crate::config::toprepo_git_config;
 
     #[test]
     fn test_main_outside_git_toprepo() {
@@ -869,9 +871,10 @@ mod tests {
         let _ = init_cmd.arg("init").output();
         let argv = vec!["git-toprepo", "-C", temp_dir_str, "config", "show"];
         let argv = argv.into_iter().map(|s| s.into());
+        let key = toprepo_git_config(TOPREPO_CONFIG_FILE_KEY);
         assert_eq!(
             format!("{:#}", main_impl(argv, None).unwrap_err()),
-            "git-config 'toprepo.config' is missing. Is this an initialized git-toprepo?",
+            format!("git-config '{key}' is missing. Is this an initialized git-toprepo?"),
         );
     }
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,3 +1,5 @@
+use crate::config::TOPREPO_CONFIG_FILE_KEY;
+use crate::config::toprepo_git_config;
 use crate::git::BlobId;
 use crate::git::CommitId;
 use crate::git::GitModulesInfo;
@@ -139,16 +141,17 @@ impl TopRepo {
             .safe_status()?
             .check_success()
             .context("Failed to set git-config remote.origin.tagOpt")?;
+        let key = &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY);
         git_command(directory)
             .args([
                 "config",
-                "toprepo.config",
+                key,
                 &format!("repo:{toprepo_ref_prefix}refs/remotes/origin/HEAD:.gittoprepo.toml"),
             ])
             .trace_command(crate::command_span!("git config"))
             .safe_status()?
             .check_success()
-            .context("Failed to set git-config toprepo.config")?;
+            .context("Failed to set git-config {key}")?;
 
         let result = {
             let (process, _span_guard) = git_command(directory)

--- a/tests/integration/config.rs
+++ b/tests/integration/config.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use git_toprepo::config::TOPREPO_CONFIG_FILE_KEY;
+use git_toprepo::config::toprepo_git_config;
 use git_toprepo::git::commit_env_for_testing;
 use git_toprepo::git::git_command;
 use git_toprepo::util::CommandExtension as _;
@@ -44,7 +45,7 @@ fn test_validate_external_file_in_corrupt_repository() {
     git_command(&temp_dir)
         .args([
             "config",
-            TOPREPO_CONFIG_FILE_KEY,
+            &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
             &format!("worktree:{invalid_toml}"),
         ])
         .envs(&deterministic)


### PR DESCRIPTION
The config file config key used the old namespace. This unifies all git config keys into one namespace.