### PR TITLE
Tidy: Implement Copy trait for *CommitId structs

### DIFF
--- a/src/expander.rs
+++ b/src/expander.rs
@@ -213,7 +213,7 @@ impl TopRepoExpander<'_> {
             let mono_commit_id = MonoRepoCommitId::new(commit_ids[*mark - 1]);
             self.storage
                 .monorepo_commits
-                .insert(mono_commit_id.clone(), mono_commit.clone());
+                .insert(mono_commit_id, mono_commit.clone());
             self.storage
                 .monorepo_commit_ids
                 .insert(RcKey::new(mono_commit), mono_commit_id);
@@ -1163,7 +1163,7 @@ impl BumpCache {
         // TODO: Is caching needed?
         loop {
             if let Some(top_bump) = &mono_commit.top_bump {
-                return Some(top_bump.clone());
+                return Some(*top_bump);
             }
             let Some(MonoRepoParent::Mono(first_parent)) = mono_commit.parents.first() else {
                 return None;
@@ -1598,7 +1598,7 @@ fn refilter(
                         .monorepo_commit_ids
                         .get(&RcKey::new(mono_commit))
                 {
-                    monorepo_object_tips.push((monorepo_ref_name, mono_commit_id.clone()));
+                    monorepo_object_tips.push((monorepo_ref_name, *mono_commit_id));
                 } else {
                     todo_toprepo_object_tips.push((monorepo_ref_name, r.name, commit_id));
                 }
@@ -1684,7 +1684,7 @@ fn refilter(
                 .monorepo_commit_ids
                 .get(&RcKey::new(mono_commit))
                 .expect("just filtered mono commit id must exist");
-            monorepo_object_tips.push((monorepo_ref_name, mono_commit_id.clone()));
+            monorepo_object_tips.push((monorepo_ref_name, *mono_commit_id));
         }
     }
     // TODO: Update all refs here and not while running git-fast-import. By

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -371,7 +371,7 @@ impl<'a> MonoRepoProcessor<'a> {
 
 #[serde_as]
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
 pub struct TopRepoCommitId(
     #[serde_as(as = "serde_with::IfIsHumanReadable<serde_with::DisplayFromStr>")] CommitId,
@@ -433,7 +433,7 @@ pub enum MonoRepoParent {
 /// While importing, the commit id might not yet be known and set to a dummy id.
 #[serde_as]
 #[derive(
-    Debug, Clone, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+    Debug, Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
 pub struct MonoRepoCommitId(
     #[serde_as(as = "serde_with::IfIsHumanReadable<serde_with::DisplayFromStr>")] CommitId,

--- a/src/repo_cache_serde.rs
+++ b/src/repo_cache_serde.rs
@@ -191,13 +191,13 @@ impl SerdeTopRepoCache {
         }
         let mut monorepo_commits = HashMap::with_capacity(self.monorepo_commits.len());
         for serde_commit in self.monorepo_commits {
-            let commit_id = serde_commit.commit_id.clone();
+            let commit_id = serde_commit.commit_id;
             let mono_commit = serde_commit.unpack(&monorepo_commits)?;
             monorepo_commits.insert(commit_id, mono_commit);
         }
         let monorepo_commit_ids = monorepo_commits
             .iter()
-            .map(|(commit_id, commit)| (RcKey::new(commit), commit_id.clone()))
+            .map(|(commit_id, commit)| (RcKey::new(commit), *commit_id))
             .collect();
         let top_to_mono_map = self
             .top_to_mono_map
@@ -237,12 +237,11 @@ impl SerdeTopRepoCache {
             .iter()
             .map(|(top_commit_id, mono_commit)| {
                 (
-                    top_commit_id.clone(),
-                    cache
+                    *top_commit_id,
+                    *cache
                         .monorepo_commit_ids
                         .get(&RcKey::new(mono_commit))
-                        .unwrap()
-                        .clone(),
+                        .unwrap(),
                 )
             })
             .collect();
@@ -442,20 +441,18 @@ impl SerdeMonoRepoCommit {
                     SerdeMonoRepoParent::OriginalSubmod(original_submod.clone())
                 }
                 MonoRepoParent::Mono(monorepo_commit) => SerdeMonoRepoParent::Mono(
-                    commit_ids
+                    *commit_ids
                         .get(&RcKey::new(monorepo_commit))
-                        .expect("mono commit parents have commit ids")
-                        .clone(),
+                        .expect("mono commit parents have commit ids"),
                 ),
             })
             .collect();
         Self {
-            commit_id: commit_ids
+            commit_id: *commit_ids
                 .get(&RcKey::new(commit))
-                .expect("mono commits have commit ids")
-                .clone(),
+                .expect("mono commits have commit ids"),
             parents,
-            top_bump: commit.top_bump.clone(),
+            top_bump: commit.top_bump,
             submodule_bumps: commit.submodule_bumps.clone(),
         }
     }


### PR DESCRIPTION
MonoRepoCommitId and TopRepoCommitId are just wrapping gix::ObjectId and are so small that .clone() is unnecessary. Let's use the Copy trait instead.