### PR TITLE
Prune refs in top repo fetch, not just submodules

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -56,6 +56,7 @@ impl RemoteFetcher {
             Some(name) => Some(name.to_str()?.to_string()),
             None => Some("origin".to_owned()),
         };
+        self.args.push("--prune".to_owned());
         Ok(())
     }
 
@@ -114,6 +115,7 @@ impl RemoteFetcher {
                         .with_context(|| format!("Fetch URL for {name_or_url} is missing"))?
                         .to_string(),
                 );
+                self.args.push("--prune".to_owned());
             }
             None => {
                 // Not the super repo, try to find the subrepo.

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,6 +376,7 @@ fn fetch_with_default_refspecs(
         );
     }
     fetcher.remote = fetch_args.remote.clone();
+    fetcher.args.push("--prune".to_owned());
     fetcher.fetch_on_terminal()?;
 
     if !fetch_args.skip_filter {


### PR DESCRIPTION
This fix is not elegant. Please refactor later.