### PR TITLE
Replace GitPath::new(x.into()) with GitPath::from(x)

### DIFF
--- a/src/expander.rs
+++ b/src/expander.rs
@@ -1297,7 +1297,6 @@ impl Default for BumpCache {
 /// use git_toprepo::repo::ExpandedOrRemovedSubmodule;
 /// use git_toprepo::repo::ExpandedSubmodule;
 ///
-/// use bstr::B;
 /// use bstr::ByteSlice;
 /// use std::collections::HashMap;
 /// use std::rc::Rc;
@@ -1305,11 +1304,11 @@ impl Default for BumpCache {
 /// let mut submod_updates = HashMap::new();
 /// let subx_commit_id: CommitId = gix::ObjectId::from_hex(b"1234567890abcdef1234567890abcdef12345678").unwrap();
 /// submod_updates.insert(
-///     GitPath::new(B("subx").into()),
+///     GitPath::from("subx"),
 ///     ExpandedOrRemovedSubmodule::Expanded(ExpandedSubmodule::KeptAsSubmodule(subx_commit_id)),
 /// );
 /// submod_updates.insert(
-///     GitPath::new(B("suby").into()),
+///     GitPath::from("suby"),
 ///     ExpandedOrRemovedSubmodule::Removed,
 /// );
 ///

--- a/src/git.rs
+++ b/src/git.rs
@@ -47,13 +47,13 @@ impl GitPath {
     ///
     /// ```
     /// use git_toprepo::git::GitPath;
-    /// use bstr::ByteSlice as _;
-    /// let empty_path = GitPath::new(b"".into());
-    /// let foo = GitPath::new(b"foo".into());
-    /// let bar = GitPath::new(b"bar".into());
-    /// assert_eq!(foo.join(&bar), GitPath::new(b"foo/bar".into()));
-    /// assert_eq!(foo.join(&empty_path), GitPath::new(b"foo".into()));
-    /// assert_eq!(empty_path.join(&bar), GitPath::new(b"bar".into()));
+    ///
+    /// let empty_path = GitPath::from("");
+    /// let foo = GitPath::from("foo");
+    /// let bar = GitPath::from("bar");
+    /// assert_eq!(foo.join(&bar), GitPath::from("foo/bar"));
+    /// assert_eq!(foo.join(&empty_path), GitPath::from("foo"));
+    /// assert_eq!(empty_path.join(&bar), GitPath::from("bar"));
     /// ```
     pub fn join(&self, other: &GitPath) -> Self {
         if self.is_empty() {
@@ -73,14 +73,14 @@ impl GitPath {
     ///
     /// ```
     /// use git_toprepo::git::GitPath;
-    /// use bstr::ByteSlice as _;
-    /// let empty_path = GitPath::new(b"".into());
-    /// let foo_bar = GitPath::new(b"foo/bar".into());
-    /// let foo = GitPath::new(b"foo".into());
-    /// let bar = GitPath::new(b"bar".into());
-    /// assert_eq!(foo_bar.relative_to(&foo), Some(GitPath::new(b"bar".into())));
-    /// assert_eq!(foo_bar.relative_to(&foo_bar), Some(GitPath::new(b"".into())));
-    /// assert_eq!(foo_bar.relative_to(&empty_path), Some(GitPath::new(b"foo/bar".into())));
+    ///
+    /// let empty_path = GitPath::from("");
+    /// let foo_bar = GitPath::from("foo/bar");
+    /// let foo = GitPath::from("foo");
+    /// let bar = GitPath::from("bar");
+    /// assert_eq!(foo_bar.relative_to(&foo), Some(GitPath::from("bar")));
+    /// assert_eq!(foo_bar.relative_to(&foo_bar), Some(GitPath::from("")));
+    /// assert_eq!(foo_bar.relative_to(&empty_path), Some(GitPath::from("foo/bar")));
     /// assert_eq!(empty_path.relative_to(&bar), None);
     /// assert_eq!(foo_bar.relative_to(&bar), None);
     /// ```
@@ -319,9 +319,7 @@ pub fn repo_relative_path(worktree: &Path, cwd_relpath: &Path) -> Result<GitPath
     let worktree_path = wanted_path
         .strip_prefix(worktree)
         .context("Path is not relative to the worktree")?;
-    Ok(GitPath::new(
-        worktree_path.as_os_str().as_encoded_bytes().into(),
-    ))
+    Ok(GitPath::from(worktree_path.as_os_str().as_encoded_bytes()))
 }
 
 /// Scaffolding code to create deterministic commits.

--- a/src/git_fast_export_import.rs
+++ b/src/git_fast_export_import.rs
@@ -901,12 +901,8 @@ mod tests {
         commit(&top_repo, &env, "B");
         commit(&top_repo, &env, "C");
         let sub_rev_3 = commit(&sub_repo, &env, "3");
-        crate::git::git_update_submodule_in_index(
-            &top_repo,
-            &GitPath::new("sub".into()),
-            &sub_rev_3,
-        )
-        .unwrap();
+        crate::git::git_update_submodule_in_index(&top_repo, &GitPath::from("sub"), &sub_rev_3)
+            .unwrap();
 
         commit(&top_repo, &env, "D");
         top_repo

--- a/src/push.rs
+++ b/src/push.rs
@@ -163,11 +163,11 @@ fn resolve_push_repo(
     config: &mut crate::config::GitTopRepoConfig,
 ) -> Result<(RepoName, GitPath, GitPath, gix::Url)> {
     let mut repo_name = RepoName::Top;
-    let mut repo_path = GitPath::new(b"".into());
+    let mut repo_path = GitPath::from("");
     let mut rel_path = path;
     let mut generic_url = EMPTY_GIX_URL.clone();
     loop {
-        let dot_gitmodules_path = repo_path.join(&GitPath::new(b".gitmodules".into()));
+        let dot_gitmodules_path = repo_path.join(&GitPath::from(".gitmodules"));
         let dot_gitmodules_bytes = match mono_commit
             .tree()?
             .lookup_entry_by_path(dot_gitmodules_path.to_path()?)?
@@ -191,13 +191,12 @@ fn resolve_push_repo(
             return Ok((repo_name, repo_path, rel_path.clone(), push_url));
         };
         // Apply one submodule level.
-        rel_path = GitPath::new(
+        rel_path = GitPath::from(
             rel_path
                 .strip_prefix(submod_path.as_bytes())
                 .expect("part of the submodule")
                 .strip_prefix(b"/")
-                .expect("part of the submodule")
-                .into(),
+                .expect("part of the submodule"),
         );
         repo_path = repo_path.join(submod_path);
         let sub_url = match sub_url {


### PR DESCRIPTION
Use less code and describe the initialization the same way in the whole code base.