### PR TITLE
Allow pushing existing remote ref

### DIFF
--- a/tests/integration/push.rs
+++ b/tests/integration/push.rs
@@ -33,6 +33,35 @@ fn test_push_empty_commit_should_fail() {
 }
 
 #[test]
+fn test_push_duplicate_branch() {
+    let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
+    let toprepo = temp_dir.join("top");
+    let monorepo = temp_dir.join("mono");
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    Command::cargo_bin("git-toprepo")
+        .unwrap()
+        .current_dir(&monorepo)
+        .args(["push", "origin", "HEAD:refs/heads/new-branch"])
+        .assert()
+        .success();
+
+    // It is enough to push to the top repository, as the submodules are not
+    // changed and their commits are already present but potentially under a
+    // different ref.
+    Command::new("git")
+        .current_dir(&toprepo)
+        .args([
+            "diff",
+            "--exit-code",
+            "refs/heads/main",
+            "refs/heads/new-branch",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
 fn test_push_top() {
     let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
     let toprepo = temp_dir.join("top");


### PR DESCRIPTION
Pushing an existing remote ref will only push to the remote top repository, all the submodules are already referencing the needed commit under some ref. Creating a branch in all the submodules is not implemented.