### PR TITLE
Make all git calls deterministic during testing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -621,7 +621,7 @@ pub struct PushConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::super::git::commit_env_for_testing;
+    use super::super::git::git_command_for_testing;
     use super::*;
     use assert_cmd::assert::OutputAssertExt as _;
 
@@ -639,21 +639,18 @@ mod tests {
         let tmp_path = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
             "git_toprepo-test_create_config_from_invalid_ref",
         );
-        let env = commit_env_for_testing();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["init"])
-            .envs(&env)
             .assert()
             .success();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args([
                 "config",
                 &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
                 "worktree:foobar.toml",
             ])
-            .envs(&env)
             .assert()
             .success();
 
@@ -671,11 +668,9 @@ mod tests {
         let tmp_path = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
             "git_toprepo-test_create_config_from_worktree",
         );
-        let env = commit_env_for_testing();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["init"])
-            .envs(&env)
             .assert()
             .success();
 
@@ -683,19 +678,17 @@ mod tests {
 
         writeln!(tmp_file, "{BAR_BAZ}").unwrap();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["add", "foobar.toml"])
-            .envs(&env)
             .assert()
             .success();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args([
                 "config",
                 &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
                 "worktree:foobar.toml",
             ])
-            .envs(&env)
             .assert()
             .success();
 
@@ -728,22 +721,19 @@ mod tests {
         let tmp_path = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
             "git_toprepo-test_missing_config",
         );
-        let env = commit_env_for_testing();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["init"])
-            .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["commit", "--allow-empty", "-m", "Initial commit"])
-            .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
         // Try a path in the repository.
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args([
                 "config",
                 &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
@@ -762,7 +752,7 @@ mod tests {
         );
 
         // Try the worktree.
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args([
                 "config",
                 &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
@@ -811,52 +801,45 @@ mod tests {
         let tmp_path = git_toprepo_testtools::test_util::MaybePermanentTempDir::new_with_prefix(
             "git_toprepo-test_create_config_from_head",
         );
-        let env = commit_env_for_testing();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["init"])
-            .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
         let mut tmp_file = std::fs::File::create(tmp_path.join(".gittoprepo.toml")).unwrap();
         writeln!(tmp_file, "{BAR_BAZ}").unwrap();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["add", ".gittoprepo.toml"])
-            .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["commit", "-m", "Initial commit"])
-            .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args([
                 "update-ref",
                 "refs/namespaces/top/refs/remotes/origin/HEAD",
                 "HEAD",
             ])
-            .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["rm", ".gittoprepo.toml"])
-            .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args(["commit", "-m", "Remove .gittoprepo.toml"])
-            .envs(&env)
             .check_success_with_stderr()
             .unwrap();
 
-        git_command(&tmp_path)
+        git_command_for_testing(&tmp_path)
             .args([
                 "config",
                 &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use colored::Colorize;
 use git_toprepo::config;
 use git_toprepo::config::GitTopRepoConfig;
 use git_toprepo::git::GitModulesInfo;
-use git_toprepo::git::git_command;
 use git_toprepo::log::CommandSpanExt as _;
 use git_toprepo::log::ErrorMode;
 use git_toprepo::log::ErrorObserver;
@@ -78,7 +77,7 @@ fn clone_after_init(clone_args: &cli::Clone, processor: &mut MonoRepoProcessor) 
         processor.reload_config()?;
         refilter(&clone_args.refilter, processor)?;
     }
-    git_command(Path::new("."))
+    std::process::Command::new("git")
         .args(["checkout", "refs/remotes/origin/HEAD", "--"])
         .trace_command(git_toprepo::command_span!("git checkout"))
         .check_success_with_stderr()?;
@@ -849,6 +848,7 @@ mod tests {
     use super::*;
     use crate::config::TOPREPO_CONFIG_FILE_KEY;
     use crate::config::toprepo_git_config;
+    use git_toprepo::git::git_command_for_testing;
 
     #[test]
     fn test_main_outside_git_toprepo() {
@@ -873,7 +873,7 @@ mod tests {
             "git_toprepo-test_main_outside_git_toprepo",
         );
         let temp_dir_str = temp_dir.to_str().unwrap();
-        let mut init_cmd = git_command(&temp_dir.to_path_buf().to_owned());
+        let mut init_cmd = git_command_for_testing(&temp_dir);
         let _ = init_cmd.arg("init").output();
         let argv = vec!["git-toprepo", "-C", temp_dir_str, "config", "show"];
         let argv = argv.into_iter().map(|s| s.into());

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -6,7 +6,6 @@ use crate::git::GitModulesInfo;
 use crate::git::GitPath;
 use crate::git::TreeId;
 use crate::git::git_command;
-use crate::git::git_global_command;
 use crate::git_fast_export_import::WithoutCommitterId;
 use crate::git_fast_export_import_dedup::GitFastExportImportDedupCache;
 use crate::log::CommandSpanExt as _;
@@ -75,7 +74,7 @@ pub struct TopRepo {
 
 impl TopRepo {
     pub fn create(directory: &Path, url: gix::url::Url) -> Result<TopRepo> {
-        git_global_command()
+        std::process::Command::new("git")
             .arg("init")
             .arg("--quiet")
             .arg(directory.as_os_str())

--- a/tests/integration/clone.rs
+++ b/tests/integration/clone.rs
@@ -1,9 +1,8 @@
 use anyhow::Context as _;
 use assert_cmd::prelude::*;
 use bstr::ByteSlice as _;
-use git_toprepo::git::git_command;
+use git_toprepo::git::git_command_for_testing;
 use predicates::prelude::*;
-use std::collections::HashMap;
 use std::process::Command;
 
 #[test]
@@ -16,43 +15,27 @@ fn test_toprepo_clone() {
     let to_path = &base_dir.path().join("to");
     std::fs::create_dir(to_path).unwrap();
 
-    // TODO: Can this use the deterministic environment setup?
-    // Or are these particular values important?
-    let env = HashMap::from([
-        ("GIT_AUTHOR_NAME", "A Name"),
-        ("GIT_AUTHOR_EMAIL", "a@no.example"),
-        ("GIT_AUTHOR_DATE", "2023-01-02T03:04:05Z+01:00"),
-        ("GIT_COMMITTER_NAME", "C Name"),
-        ("GIT_COMMITTER_EMAIL", "c@no.example"),
-        ("GIT_COMMITTER_DATE", "2023-06-07T08:09:10Z+01:00"),
-    ]);
-
-    git_command(from_path)
+    git_command_for_testing(from_path)
         .args(["init", "--quiet", "--initial-branch", "main"])
-        .envs(&env)
         .assert()
         .success();
-    git_command(from_path)
+    git_command_for_testing(from_path)
         .args(["commit", "--allow-empty", "--quiet"])
         .args(["-m", "Initial commit"])
-        .envs(&env)
         .assert()
         .success();
     std::fs::write(from_path.join(".gittoprepo.toml"), "").unwrap();
-    git_command(from_path)
+    git_command_for_testing(from_path)
         .args(["add", ".gittoprepo.toml"])
-        .envs(&env)
         .assert()
         .success();
-    git_command(from_path)
+    git_command_for_testing(from_path)
         .args(["commit", "--quiet"])
         .args(["-m", "Config file"])
-        .envs(&env)
         .assert()
         .success();
-    git_command(from_path)
+    git_command_for_testing(from_path)
         .args(["tag", "mytag"])
-        .envs(&env)
         .assert()
         .success();
 
@@ -81,14 +64,14 @@ fn test_toprepo_clone() {
         ("mytag", "refs/namespaces/top/refs/tags/mytag"),
     ];
     for (orig_ref, top_ref) in ref_pairs {
-        let orig_rev = git_command(from_path)
+        let orig_rev = git_command_for_testing(from_path)
             .args(["rev-parse", "--verify", orig_ref])
             .assert()
             .success()
             .get_output()
             .stdout
             .clone();
-        let top_rev = git_command(to_gix_repo.git_dir())
+        let top_rev = git_command_for_testing(to_gix_repo.git_dir())
             .args(["rev-parse", "--verify", top_ref])
             .assert()
             .success()

--- a/tests/integration/dump.rs
+++ b/tests/integration/dump.rs
@@ -1,5 +1,5 @@
 use assert_cmd::prelude::*;
-use git_toprepo::git::git_command;
+use git_toprepo::git::git_command_for_testing;
 use predicate::str::contains;
 use predicates::prelude::*;
 use std::process::Command;
@@ -60,8 +60,7 @@ fn test_dump_git_modules() {
         .failure()
         .stderr(contains("Loading the main repo Gerrit project"));
 
-    Command::new("git")
-        .current_dir(&temp_dir)
+    git_command_for_testing(&temp_dir)
         .arg("remote")
         .arg("add")
         .arg("origin")
@@ -97,7 +96,7 @@ fn test_wrong_cache_prelude() {
         "git_toprepo-test_wrong_cache_prelude",
     );
 
-    git_command(&temp_dir)
+    git_command_for_testing(&temp_dir)
         .args(["init", "--quiet"])
         .assert()
         .success();

--- a/tests/integration/push.rs
+++ b/tests/integration/push.rs
@@ -1,6 +1,5 @@
 use assert_cmd::prelude::*;
-use git_toprepo::git::commit_env_for_testing;
-use git_toprepo::git::git_command;
+use git_toprepo::git::git_command_for_testing;
 use git_toprepo::util::NewlineTrimmer as _;
 use itertools::Itertools as _;
 use predicates::prelude::*;
@@ -13,10 +12,8 @@ fn test_push_empty_commit_should_fail() {
     let monorepo = temp_dir.join("mono");
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
 
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "--allow-empty", "-m", "Empty commit"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
@@ -51,8 +48,7 @@ fn test_push_duplicate_branch() {
     // It is enough to push to the top repository, as the submodules are not
     // changed and their commits are already present but potentially under a
     // different ref.
-    Command::new("git")
-        .current_dir(&toprepo)
+    git_command_for_testing(&toprepo)
         .args([
             "diff",
             "--exit-code",
@@ -71,15 +67,12 @@ fn test_push_top() {
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
 
     std::fs::write(monorepo.join("file.txt"), "text\n").unwrap();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "file.txt"])
         .assert()
         .success();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add file"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
@@ -95,8 +88,7 @@ fn test_push_top() {
         )))
         .stderr(predicate::str::is_match(r"\n \* \[new branch\]\s+[0-9a-f]+ -> foo\n").unwrap());
 
-    Command::new("git")
-        .current_dir(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["show", "refs/heads/foo:file.txt"])
         .assert()
         .success()
@@ -111,15 +103,12 @@ fn test_push_submodule() {
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
 
     std::fs::write(monorepo.join("sub/file.txt"), "text\n").unwrap();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "sub/file.txt"])
         .assert()
         .success();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add file"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
@@ -135,8 +124,7 @@ fn test_push_submodule() {
         )))
         .stderr(predicate::str::is_match(r"\n \* \[new branch\]\s+[0-9a-f]+ -> foo\n").unwrap());
 
-    Command::new("git")
-        .current_dir(toprepo.join("../sub"))
+    git_command_for_testing(toprepo.join("../sub"))
         .args(["show", "refs/heads/foo:file.txt"])
         .assert()
         .success()
@@ -151,20 +139,16 @@ fn test_push_revision() {
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
 
     std::fs::write(monorepo.join("file.txt"), "text\n").unwrap();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "file.txt"])
         .assert()
         .success();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add file"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
-    let cmd = Command::new("git")
-        .current_dir(&monorepo)
+    let cmd = git_command_for_testing(&monorepo)
         .args(["rev-parse", "HEAD"])
         .assert()
         .success();
@@ -195,15 +179,12 @@ fn test_push_from_sub_directory() {
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
 
     std::fs::write(monorepo.join("file.txt"), "text\n").unwrap();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "file.txt"])
         .assert()
         .success();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add file"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
@@ -220,8 +201,7 @@ fn test_push_from_sub_directory() {
         )))
         .stderr(predicate::str::is_match(r"\n \* \[new branch\]\s+[0-9a-f]+ -> foo\n").unwrap());
 
-    Command::new("git")
-        .current_dir(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["show", "refs/heads/foo:file.txt"])
         .assert()
         .success()
@@ -236,22 +216,17 @@ fn test_push_shortrev() {
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
 
     std::fs::write(monorepo.join("file.txt"), "text\n").unwrap();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "file.txt"])
         .assert()
         .success();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add file"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
-    let cmd = Command::new("git")
-        .current_dir(&monorepo)
+    let cmd = git_command_for_testing(&monorepo)
         .args(["rev-parse", "--short", "HEAD"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
     let output = cmd.get_output();
@@ -270,8 +245,7 @@ fn test_push_shortrev() {
         )))
         .stderr(predicate::str::is_match(r"\n \* \[new branch\]\s+[0-9a-f]+ -> foo\n").unwrap());
 
-    Command::new("git")
-        .current_dir(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["show", "refs/heads/foo:file.txt"])
         .assert()
         .success()
@@ -289,15 +263,12 @@ fn test_push_top_and_submodule_in_series() {
     std::fs::write(monorepo.join("file.txt"), "top\n").unwrap();
     std::fs::write(monorepo.join("sub/file.txt"), "submodule\n").unwrap();
 
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "file.txt", "sub/file.txt"])
         .assert()
         .success();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add files\n\nTopic: my-topic"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
@@ -330,14 +301,12 @@ To .*/top/?
             .unwrap(),
         );
 
-    Command::new("git")
-        .current_dir(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["show", "refs/heads/foo:file.txt"])
         .assert()
         .success()
         .stdout("top\n");
-    Command::new("git")
-        .current_dir(&subrepo)
+    git_command_for_testing(&subrepo)
         .args(["show", "refs/heads/foo:file.txt"])
         .assert()
         .success()
@@ -355,15 +324,12 @@ fn test_push_top_and_submodule_in_parallel() {
     std::fs::write(monorepo.join("file.txt"), "top\n").unwrap();
     std::fs::write(monorepo.join("sub/file.txt"), "submodule\n").unwrap();
 
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "file.txt", "sub/file.txt"])
         .assert()
         .success();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add files\n\nTopic: my-topic"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
@@ -397,14 +363,12 @@ To .*
             .unwrap(),
         );
 
-    Command::new("git")
-        .current_dir(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["show", "refs/heads/foo:file.txt"])
         .assert()
         .success()
         .stdout("top\n");
-    Command::new("git")
-        .current_dir(&subrepo)
+    git_command_for_testing(&subrepo)
         .args(["show", "refs/heads/foo:file.txt"])
         .assert()
         .success()
@@ -422,15 +386,12 @@ fn test_push_topic_removed_from_commit_message() {
     std::fs::write(monorepo.join("file.txt"), "top\n").unwrap();
     std::fs::write(monorepo.join("sub/file.txt"), "submodule\n").unwrap();
 
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "file.txt", "sub/file.txt"])
         .assert()
         .success();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add files\n\nTopic: my-topic"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
@@ -442,14 +403,12 @@ fn test_push_topic_removed_from_commit_message() {
         .success();
 
     // Check for missing topic and a single LF at the end.
-    Command::new("git")
-        .current_dir(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["cat-file", "-p", "refs/heads/foo"])
         .assert()
         .success()
         .stdout(predicate::str::ends_with("\n\nAdd files\n"));
-    Command::new("git")
-        .current_dir(&subrepo)
+    git_command_for_testing(&subrepo)
         .args(["cat-file", "-p", "refs/heads/foo"])
         .assert()
         .success()
@@ -465,15 +424,12 @@ fn test_push_topic_is_used_as_push_option() {
 
     std::fs::write(monorepo.join("file.txt"), "top\n").unwrap();
 
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "file.txt"])
         .assert()
         .success();
-    Command::new("git")
-        .current_dir(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add file\n\nTopic: my-topic"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
 
@@ -504,13 +460,12 @@ fn test_topic_is_required_for_multi_repo_push() {
     std::fs::write(monorepo.join("top.txt"), "top\n").unwrap();
     std::fs::write(monorepo.join("subx/file.txt"), "subx\n").unwrap();
     std::fs::write(monorepo.join("suby/file.txt"), "suby\n").unwrap();
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "top.txt", "subx/file.txt", "suby/file.txt"])
         .assert()
         .success();
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add files"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
     assert_cmd::Command::cargo_bin("git-toprepo")
@@ -538,13 +493,12 @@ fn test_force_push() {
     std::fs::write(monorepo.join("top.txt"), "top\n").unwrap();
     std::fs::write(monorepo.join("subx/file.txt"), "subx\n").unwrap();
     std::fs::write(monorepo.join("suby/file.txt"), "suby\n").unwrap();
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["add", "top.txt"])
         .assert()
         .success();
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "-m", "Add file"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
     assert_cmd::Command::cargo_bin("git-toprepo")
@@ -555,9 +509,8 @@ fn test_force_push() {
         .success();
 
     // --force
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args(["commit", "--amend", "-m", "Force"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
     assert_cmd::Command::cargo_bin("git-toprepo")

--- a/tests/integration/refilter.rs
+++ b/tests/integration/refilter.rs
@@ -1,8 +1,7 @@
 use assert_cmd::Command;
 use assert_cmd::assert::OutputAssertExt as _;
 use bstr::ByteSlice as _;
-use git_toprepo::git::commit_env_for_testing;
-use git_toprepo::git::git_command;
+use git_toprepo::git::git_command_for_testing;
 use itertools::Itertools as _;
 use predicates::prelude::PredicateBooleanExt as _;
 use std::path::Path;
@@ -368,7 +367,7 @@ fn test_refilter_moved_submodule() {
 }
 
 fn extract_log_graph(repo_path: &Path, extra_args: Vec<&str>) -> String {
-    let log_command = git_command(repo_path)
+    let log_command = git_command_for_testing(repo_path)
         .args(["log", "--graph", "--format=%s"])
         .args(extra_args)
         .assert()
@@ -403,13 +402,12 @@ fn test_warn_for_empty_submodule() {
     let monorepo = temp_dir.join("mono");
     let monorepo2 = temp_dir.join("mono2");
 
-    git_command(&subxrepo)
+    git_command_for_testing(&subxrepo)
         .args(["rm", "-rf", "."])
         .assert()
         .success();
-    git_command(&subxrepo)
+    git_command_for_testing(&subxrepo)
         .args(["commit", "-m", "Remove all files"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
     Command::cargo_bin("git-toprepo")
@@ -423,13 +421,12 @@ fn test_warn_for_empty_submodule() {
 
     // Fix the warning.
     std::fs::write(subxrepo.join("file.txt"), "content\n").unwrap();
-    git_command(&subxrepo)
+    git_command_for_testing(&subxrepo)
         .args(["add", "file.txt"])
         .assert()
         .success();
-    git_command(&subxrepo)
+    git_command_for_testing(&subxrepo)
         .args(["commit", "-m", "add a file"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
     Command::cargo_bin("git-toprepo")
@@ -466,7 +463,7 @@ fn test_refilter_prints_updates() {
  * [new] e1f32c7      -> origin/main
 ",
         );
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args([
             "symbolic-ref",
             "refs/namespaces/top/refs/symbolic/good",
@@ -474,7 +471,7 @@ fn test_refilter_prints_updates() {
         ])
         .assert()
         .success();
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args([
             "symbolic-ref",
             "refs/namespaces/top/refs/symbolic/outside-top",
@@ -482,7 +479,7 @@ fn test_refilter_prints_updates() {
         ])
         .assert()
         .success();
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args([
             "update-ref",
             "-d",
@@ -490,7 +487,7 @@ fn test_refilter_prints_updates() {
         ])
         .assert()
         .success();
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args([
             "update-ref",
             "refs/namespaces/top/refs/remotes/origin/other",
@@ -498,7 +495,7 @@ fn test_refilter_prints_updates() {
         ])
         .assert()
         .success();
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args([
             "update-ref",
             "refs/namespaces/top/refs/tags/v1.0",
@@ -506,7 +503,7 @@ fn test_refilter_prints_updates() {
         ])
         .assert()
         .success();
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args([
             "update-ref",
             "refs/namespaces/top/refs/tags/v2.0",
@@ -533,7 +530,7 @@ fn test_refilter_prints_updates() {
 "[1..]);
 
     // Symbolic refs are never pruned, so delete it manually.
-    git_command(&monorepo)
+    git_command_for_testing(&monorepo)
         .args([
             "update-ref",
             "-d",
@@ -542,20 +539,19 @@ fn test_refilter_prints_updates() {
         ])
         .assert()
         .success();
-    git_command(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["commit", "--allow-empty", "-m", "Empty commit"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
-    git_command(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["branch", "other", "HEAD"])
         .assert()
         .success();
-    git_command(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["reset", "HEAD~"])
         .assert()
         .success();
-    git_command(&toprepo)
+    git_command_for_testing(&toprepo)
         .args([
             "commit",
             "--amend",
@@ -563,18 +559,15 @@ fn test_refilter_prints_updates() {
             "-m",
             "Different message",
         ])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
-    git_command(&toprepo)
+    git_command_for_testing(&toprepo)
         .args(["tag", "-m", "Version 1.0", "v1.0", "HEAD"])
-        .envs(commit_env_for_testing())
         .assert()
         .success();
-    git_command(&toprepo)
+    git_command_for_testing(&toprepo)
         // If this tag would not be nested, it would get the same hash as v1.0.
         .args(["tag", "-m", "Version 1.0", "v1.0-nested", "v1.0"])
-        .envs(commit_env_for_testing())
         .assert()
         .stderr(predicates::str::contains("You have created a nested tag."))
         .success();


### PR DESCRIPTION
Avoid using the user git-config and set environment variables in all calls to git during testing to make all tests deterministic.

Fixes #169.