### PR TITLE
Move cache to .git/toprepo/import-cache.bincode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -767,7 +767,7 @@ fn dump_import_cache(args: &cli::DumpImportCache) -> Result<()> {
         // Demand a configured repository to ensure we not just fall back to empty
         // cache content when not even inside a git-toprepo emulated monorepo.
         let _ = GitTopRepoConfig::find_configuration_location(&repo)?;
-        git_toprepo::repo_cache_serde::SerdeImportCache::load_from_git_dir(repo.git_dir(), None)?
+        git_toprepo::repo_cache_serde::SerdeImportCache::load_from_git_dir(&repo, None)?
     };
     serde_repo_states.dump_as_json(std::io::stdout())?;
     println!();

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -309,7 +309,7 @@ Initial empty git-toprepo configuration
             missing_subrepos: std::collections::HashSet::new(),
         };
         let import_cache = crate::repo_cache_serde::SerdeImportCache::load_from_git_dir(
-            gix_repo.git_dir(),
+            &gix_repo,
             Some(&config.checksum),
         )
         .with_context(|| format!("Loading cache from {}", gix_repo.git_dir().display()))?
@@ -330,7 +330,7 @@ Initial empty git-toprepo configuration
             &self.import_cache,
             self.config.checksum.clone(),
         )
-        .store_to_git_dir(self.gix_repo.git_dir())?;
+        .store_to_git_dir(&self.gix_repo)?;
 
         // Save effective config with ledger mutations
         const EFFECTIVE_TOPREPO_CONFIG: &str = "toprepo/last-effective-git-toprepo.toml";

--- a/src/repo_cache_serde.rs
+++ b/src/repo_cache_serde.rs
@@ -49,24 +49,27 @@ pub struct SerdeImportCache {
 }
 
 impl SerdeImportCache {
-    const TOPREPO_CACHE_PATH: &str = "toprepo/cache.bincode";
+    const TOPREPO_CACHE_PATH: &str = "toprepo/import-cache.bincode";
     const CACHE_VERSION_PRELUDE: &str = "#cache-format-v2\n";
 
     /// Constructs the path to the git repository information cache inside
     /// `.git/toprepo/`.
-    pub fn get_cache_path(git_dir: &Path) -> PathBuf {
-        git_dir.join(Self::TOPREPO_CACHE_PATH)
+    pub fn get_cache_path(repo: &gix::Repository) -> PathBuf {
+        repo.common_dir().join(Self::TOPREPO_CACHE_PATH)
     }
 
     /// Load parsed git repository information from `.git/toprepo/`.
     ///
     /// If `config_checksum` is `None`, the stored config checksum will be
     /// ignored and the cache will be considered valid.
-    pub fn load_from_git_dir(git_dir: &Path, config_checksum: Option<&str>) -> Result<Self> {
-        let cache_path = Self::get_cache_path(git_dir);
+    pub fn load_from_git_dir(
+        repo: &gix::Repository,
+        config_checksum: Option<&str>,
+    ) -> Result<Self> {
+        let cache_path = Self::get_cache_path(repo);
         let _span_guard = tracing::info_span!(
             "load_cache",
-            pach = %cache_path.display()
+            path = %cache_path.display()
         )
         .entered();
         (|| -> anyhow::Result<_> {
@@ -142,8 +145,8 @@ impl SerdeImportCache {
     }
 
     /// Store parsed git repository information to `.git/toprepo/`.
-    pub fn store_to_git_dir(&self, git_dir: &Path) -> Result<()> {
-        let cache_path = Self::get_cache_path(git_dir);
+    pub fn store_to_git_dir(&self, repo: &gix::Repository) -> Result<()> {
+        let cache_path = Self::get_cache_path(repo);
         self.store(&cache_path)
     }
 

--- a/tests/integration/dump.rs
+++ b/tests/integration/dump.rs
@@ -86,8 +86,8 @@ fn cache_from_basic_repo_should_fail() {
         .assert()
         .success();
 
-    let git_dir = temp_dir.join(".git");
-    let cache_path = git_toprepo::repo_cache_serde::SerdeImportCache::get_cache_path(&git_dir);
+    let gix_repo = gix::open(&temp_dir).unwrap();
+    let cache_path = git_toprepo::repo_cache_serde::SerdeImportCache::get_cache_path(&gix_repo);
 
     std::fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
     std::fs::write(
@@ -184,8 +184,8 @@ fn wrong_cache_prelude() {
     let monorepo = temp_dir.join("mono");
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
 
-    let git_dir = monorepo.join(".git");
-    let cache_path = git_toprepo::repo_cache_serde::SerdeImportCache::get_cache_path(&git_dir);
+    let gix_repo = gix::open(&monorepo).unwrap();
+    let cache_path = git_toprepo::repo_cache_serde::SerdeImportCache::get_cache_path(&gix_repo);
 
     std::fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
     std::fs::write(&cache_path, "wrong-#cache-format").unwrap();
@@ -211,14 +211,14 @@ fn cache_version_change_detection() {
     let monorepo = temp_dir.join("mono");
     crate::fixtures::toprepo::clone(&toprepo, &monorepo);
 
-    let cache_path =
-        git_toprepo::repo_cache_serde::SerdeImportCache::get_cache_path(&monorepo.join(".git"));
+    let gix_repo = gix::open(&monorepo).unwrap();
+    let cache_path = git_toprepo::repo_cache_serde::SerdeImportCache::get_cache_path(&gix_repo);
     let cache_bytes = std::fs::read(&cache_path).unwrap();
     assert_eq!(cache_bytes.get(0..16).unwrap(), b"#cache-format-v2");
 
     // Check that unpacking works.
     git_toprepo::repo_cache_serde::SerdeImportCache::load_from_git_dir(
-        &monorepo.join(".git"),
+        &gix_repo,
         Some("6c10545879319d948b2bcb241d61c0c31bd86a485b423d1a2cb40eb56ffe3a56"),
     )
     .unwrap()


### PR DESCRIPTION
Also move it to the .git folder of the main worktree as fetching is done in the common .git directory.