### PR TITLE
Fix .gitignore for nix /result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@
 # Cargo artifacts
 /target/
 # nix artifacts
-/result/
+/result
 # VS Code
 /.vscode/


### PR DESCRIPTION
"result" is a symlink and `/result/` only ignores directories.