### PR TITLE
Use --no-prune-tags as the expander writes refs/tags/

### DIFF
--- a/lib/testtools/test_util.rs
+++ b/lib/testtools/test_util.rs
@@ -20,7 +20,22 @@ pub fn git_command_for_testing(repo: impl AsRef<std::ffi::OsStr>) -> assert_cmd:
 /// Like [`git_toprepo::git::git_command`] but also sets environment variables
 /// for deterministic testing.
 pub fn cargo_bin_git_toprepo_for_testing() -> assert_cmd::Command {
-    assert_cmd::Command::cargo_bin("git-toprepo").unwrap()
+    let mut command = assert_cmd::Command::cargo_bin("git-toprepo").unwrap();
+    apply_git_env(&mut command);
+    // Apply the worst possible git-config to make sure git-toprepo can cope.
+    command
+        .env("GIT_CONFIG_COUNT", "4")
+        .env("GIT_CONFIG_KEY_0", "fetch.recurseSubmodules")
+        .env("GIT_CONFIG_VALUE_0", "true")
+        .env("GIT_CONFIG_KEY_1", "remote.origin.tagOpt")
+        .env("GIT_CONFIG_VALUE_1", "--tags")
+        .env("GIT_CONFIG_KEY_2", "fetch.pruneTags")
+        .env("GIT_CONFIG_VALUE_2", "true")
+        // fetch.pruneTags is not enough as git-toprepo init sets
+        // remote.origin.pruneTags which has precedence, so set that as well.
+        .env("GIT_CONFIG_KEY_3", "remote.origin.pruneTags")
+        .env("GIT_CONFIG_VALUE_3", "true");
+    command
 }
 
 fn apply_git_env(command: &mut assert_cmd::Command) {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -97,11 +97,17 @@ impl RemoteFetcher {
     }
 
     fn create_command(&self) -> std::process::Command {
+        // NOTE: Sync these default values with `ConfiguredTopRepo::create` and
+        // `testtools::test_util::git_command_for_testing`.
         let mut cmd = git_command(&self.git_dir);
         cmd.args([
             "fetch",
             "--progress",
             "--no-tags",
+            // --prune-tags will remove refs/tags/* which git-toprepo has
+            // written after expansion. Let the expander prune them instead and
+            // keep to pruning refs/namespaces/* during fetch.
+            "--no-prune-tags",
             "--no-recurse-submodules",
             "--no-auto-maintenance",
             "--no-write-commit-graph",

--- a/tests/integration/fixtures/git-upload-pack-slow/git
+++ b/tests/integration/fixtures/git-upload-pack-slow/git
@@ -1,10 +1,22 @@
 #!/bin/sh
 set -eu
 
+containsElement() {
+    local needle="$1"
+    shift
+    local element
+    for element; do
+        if [ "$element" = "$needle" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Use git-upload-pack-slow.py to simulate patchy connections during git fetch.
 # Only do so when fetching from subx.
 export PATH=$OLD_PATH
-if test "$#" -gt 10 && test "$1" = "-C" && test "$3" = "fetch" && test "${10-}" = "--negotiation-tip=refs/namespaces/subx/*"; then
+if test "$1" = "-C" && test "$3" = "fetch" && containsElement '--negotiation-tip=refs/namespaces/subx/*' "$@"; then
     script_dir=$(dirname "$0")
     working_dir="$2"
     shift 3


### PR DESCRIPTION
git-fetch updates refs/namespaces/top/refs/tags/ but not refs/tags/. Therefore, --no-prune-tags must be used when fetching to override git-config values.

The tests are updated to always set the --prune-tags config to make sure all code paths cope with a "difficult" (for git-toprepo) git-config.

Fixes #170