### PR TITLE
Move 'git-toprepo info cwd' to 'dump cwd'

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -212,8 +212,6 @@ pub enum InfoValue {
     ConfigLocation,
     /// The current git-worktree path.
     CurrentWorktree,
-    /// The current working directory.
-    Cwd,
     /// The .git directory path for the current worktree.
     GitDir,
     /// The path to the import cache file.
@@ -225,10 +223,9 @@ pub enum InfoValue {
 }
 
 impl InfoValue {
-    pub const ALL_VARIANTS: [InfoValue; 7] = [
+    pub const ALL_VARIANTS: [InfoValue; 6] = [
         InfoValue::ConfigLocation,
         InfoValue::CurrentWorktree,
-        InfoValue::Cwd,
         InfoValue::GitDir,
         InfoValue::ImportCache,
         InfoValue::MainWorktree,
@@ -241,7 +238,6 @@ impl std::fmt::Display for InfoValue {
         let s = match self {
             InfoValue::ConfigLocation => "config-location",
             InfoValue::CurrentWorktree => "current-worktree",
-            InfoValue::Cwd => "cwd",
             InfoValue::GitDir => "git-dir",
             InfoValue::ImportCache => "import-cache",
             InfoValue::MainWorktree => "main-worktree",
@@ -257,6 +253,8 @@ impl std::fmt::Display for InfoValue {
 // request issue so we can guarantee a stable API for your use-case.
 #[derive(Subcommand, Debug)]
 pub enum Dump {
+    /// Prints the current working directory, after resolving the `-C` argument.
+    Cwd,
     /// Dump the repository import cache as JSON to stdout.
     ImportCache(DumpImportCache),
     /// Dump the git submodule path mappings to remote projects.

--- a/src/main.rs
+++ b/src/main.rs
@@ -713,7 +713,6 @@ fn print_info(info_args: &cli::Info) -> Result<ExitCode> {
                     Some(path) => path.to_string_lossy().to_string(),
                     None => "<bare repository>".to_string(),
                 },
-                cli::InfoValue::Cwd => env::current_dir()?.to_string_lossy().to_string(),
                 cli::InfoValue::GitDir => repo.git_dir().to_string_lossy().to_string(),
                 cli::InfoValue::ImportCache => {
                     let cache_path =
@@ -751,6 +750,10 @@ fn print_info(info_args: &cli::Info) -> Result<ExitCode> {
 #[tracing::instrument]
 fn dump(dump_args: &cli::Dump) -> Result<()> {
     match dump_args {
+        cli::Dump::Cwd => {
+            println!("{}", env::current_dir()?.to_string_lossy());
+            Ok(())
+        }
         cli::Dump::ImportCache(args) => dump_import_cache(args),
         cli::Dump::GitModules => dump_git_modules(),
     }

--- a/tests/integration/info.rs
+++ b/tests/integration/info.rs
@@ -55,7 +55,6 @@ fn print_in_monorepo_worktree() {
         r#"
 config-location local:.gittoprepo.toml
 current-worktree {worktree}
-cwd {worktree}
 git-dir {git_dir}
 import-cache {import_cache}
 main-worktree {monorepo}
@@ -79,7 +78,6 @@ version "#,
         r#"
 config-location local:.gittoprepo.toml
 current-worktree {monorepo}
-cwd {monorepo}
 git-dir {git_dir}
 import-cache {import_cache}
 main-worktree {monorepo}
@@ -114,7 +112,6 @@ fn print_in_basic_git_repo() {
         r#"
 config-location{space}
 current-worktree {repo}
-cwd {subdir}
 git-dir {git_dir}
 import-cache {import_cache}
 main-worktree {repo}
@@ -124,7 +121,6 @@ version "#,
             .join(".git/toprepo/import-cache.bincode")
             .to_string_lossy(),
         repo = temp_dir.to_string_lossy(),
-        subdir = subdir.to_string_lossy(),
     );
     cargo_bin_git_toprepo_for_testing()
         .current_dir(&subdir)
@@ -139,10 +135,10 @@ version "#,
     cargo_bin_git_toprepo_for_testing()
         .arg("-C")
         .arg(&subdir)
-        .args(["info", "cwd"])
+        .args(["info", "git-dir"])
         .assert()
         .success()
-        .stdout(subdir.to_string_lossy().to_string() + "\n")
+        .stdout(temp_dir.join(".git").to_string_lossy().to_string() + "\n")
         .stderr("");
 }
 
@@ -165,7 +161,7 @@ fn flag_is_emulated_monorepo() {
     // --is-emulated-monorepo and a value should fail.
     cargo_bin_git_toprepo_for_testing()
         .current_dir(&temp_dir)
-        .args(["info", "--is-emulated-monorepo", "cwd"])
+        .args(["info", "--is-emulated-monorepo", "git-dir"])
         .assert()
         .code(2)
         .stdout("")


### PR DESCRIPTION
The 'cwd' is not important enough to keep as a stable API in the 'info' subcommand. Move it to the debugging interface 'dump'.

Fixes #210