### PR TITLE
Allow pushing with an original submodule commit as parent

### DIFF
--- a/tests/integration/fetch.rs
+++ b/tests/integration/fetch.rs
@@ -99,6 +99,7 @@ fn download_only_for_needed_commits() {
 100644 blob 73bf371d38ac93f7592bdee317c8ea53fead1c8c\t.gitmodules
 100644 blob ed6ed9e7ce37c1f13f718aeaf54c522610a994c2\t.gittoprepo.toml
 100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tA1-main.txt
+100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tinit.txt
 160000 commit 0123456789abcdef0123456789abcdef01234567\tsubx
 100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tsuby/y-main-1.txt
 ",
@@ -145,6 +146,7 @@ fn download_only_for_needed_commits() {
 100644 blob 73bf371d38ac93f7592bdee317c8ea53fead1c8c\t.gitmodules
 100644 blob ed6ed9e7ce37c1f13f718aeaf54c522610a994c2\t.gittoprepo.toml
 100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tA1-main.txt
+100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tinit.txt
 160000 commit 0123456789abcdef0123456789abcdef01234567\tsubx
 100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tsuby/y-main-1.txt
 ",

--- a/tests/integration/fixtures/make_minimal_with_two_submodules.sh
+++ b/tests/integration/fixtures/make_minimal_with_two_submodules.sh
@@ -37,6 +37,7 @@ git -C top add .gittoprepo.toml
 subx_rev_1=$(commit subx "x-main-1")
 suby_rev_1=$(commit suby "y-main-1")
 
+commit top "init"
 git -C top -c protocol.file.allow=always submodule add --force ../subx/ subx
 git -C top -c protocol.file.allow=always submodule add --force ../suby/ suby
 git -C top submodule deinit -f subx suby


### PR DESCRIPTION
The normal case is that a mono commit only has mono commits as parents. This fixes the edge case when an original submodule commit is a parent, basically when a submodule is added.