### PR TITLE
Don't store .git/toprepo in the local worktrees

### DIFF
--- a/src/expander.rs
+++ b/src/expander.rs
@@ -2096,7 +2096,7 @@ pub fn expand_submodule_ref_onto_head(
 
 /// Reads the monorepo refs that was the result of the last submodule expansion.
 fn read_monorepo_refs_log(repo: &gix::Repository) -> Result<Vec<FullName>> {
-    let refs_path = repo.git_dir().join("toprepo/mono-refs-ok-to-remove");
+    let refs_path = repo.common_dir().join("toprepo/mono-refs-ok-to-remove");
     if !refs_path.exists() {
         return Ok(Vec::new());
     }
@@ -2117,7 +2117,7 @@ fn read_monorepo_refs_log(repo: &gix::Repository) -> Result<Vec<FullName>> {
 
 /// Writes the monorepo refs that have resulted from the submodule expansion.
 fn write_monorepo_refs_log(repo: &gix::Repository, monorepo_refs: &[&FullName]) -> Result<()> {
-    let refs_path = repo.git_dir().join("toprepo/mono-refs-ok-to-remove");
+    let refs_path = repo.common_dir().join("toprepo/mono-refs-ok-to-remove");
     if let Some(parent) = refs_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create {}", parent.display()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -832,7 +832,7 @@ where
     let mut repo = discover_configured_repo_current_dir()?;
 
     if let Some(logger) = logger {
-        logger.write_to_git_dir(repo.gix_repo.git_dir())?;
+        logger.write_to_git_dir(repo.gix_repo.common_dir())?;
     }
 
     // Run the operation.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -315,7 +315,7 @@ Initial empty git-toprepo configuration
             &gix_repo,
             Some(&config.checksum),
         )
-        .with_context(|| format!("Loading cache from {}", gix_repo.git_dir().display()))?
+        .with_context(|| format!("Loading cache from {}", gix_repo.common_dir().display()))?
         .unpack()?;
 
         Ok(Self {
@@ -337,7 +337,7 @@ Initial empty git-toprepo configuration
 
         // Save effective config with ledger mutations
         const EFFECTIVE_TOPREPO_CONFIG: &str = "toprepo/last-effective-git-toprepo.toml";
-        let config_path = self.gix_repo.git_dir().join(EFFECTIVE_TOPREPO_CONFIG);
+        let config_path = self.gix_repo.common_dir().join(EFFECTIVE_TOPREPO_CONFIG);
         let updated_config = GitTopRepoConfig {
             checksum: self.config.checksum.clone(),
             fetch: self.config.fetch.clone(),

--- a/tests/integration/worktree.rs
+++ b/tests/integration/worktree.rs
@@ -1,8 +1,9 @@
 use git_toprepo_testtools::test_util::cargo_bin_git_toprepo_for_testing;
 use git_toprepo_testtools::test_util::git_command_for_testing;
+use predicates::prelude::*;
 
 #[test]
-fn local_config_resolution_in_worktree() {
+fn local_config_resolution() {
     let temp_dir = git_toprepo_testtools::test_util::maybe_keep_tempdir(
         gix_testtools::scripted_fixture_writable(
             "../integration/fixtures/make_minimal_with_worktree.sh",
@@ -20,4 +21,140 @@ fn local_config_resolution_in_worktree() {
         .arg("fetch")
         .assert()
         .success();
+}
+
+#[test]
+fn fetch() {
+    let temp_dir = git_toprepo_testtools::test_util::maybe_keep_tempdir(
+        gix_testtools::scripted_fixture_writable(
+            "../integration/fixtures/make_minimal_with_two_submodules.sh",
+        )
+        .unwrap(),
+    );
+    let monorepo = temp_dir.join("mono");
+    let toprepo = temp_dir.join("top");
+
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    let worktree = temp_dir.join("worktree");
+    git_command_for_testing(temp_dir.join("mono"))
+        .args(["worktree", "add", "../worktree"])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&worktree)
+        .args(["fetch", "origin", "HEAD"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(r"^ \* \[new\] [0-9a-f]+\s+-> refs/fetch-heads/0\n$").unwrap(),
+        )
+        .stderr(predicate::str::contains(
+            "INFO: Updated ../mono/.git/worktrees/worktree/FETCH_HEAD\n",
+        ));
+    // The main worktree should be missing FETCH_HEAD.
+    assert!(!std::fs::exists(monorepo.join(".git/FETCH_HEAD")).unwrap());
+    assert!(std::fs::exists(monorepo.join(".git/worktrees/worktree/FETCH_HEAD")).unwrap());
+    std::fs::remove_file(monorepo.join(".git/worktrees/worktree/FETCH_HEAD")).unwrap();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&monorepo)
+        .args(["fetch", "origin", "HEAD"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(r"^ \* \[new\] [0-9a-f]+\s+-> refs/fetch-heads/0\n$").unwrap(),
+        )
+        .stderr(predicate::str::contains("INFO: Updated .git/FETCH_HEAD\n"));
+    // Only the main worktree should have FETCH_HEAD.
+    assert!(std::fs::exists(monorepo.join(".git/FETCH_HEAD")).unwrap());
+    assert!(!std::fs::exists(monorepo.join(".git/worktrees/worktree/FETCH_HEAD")).unwrap());
+}
+
+#[test]
+fn recombine() {
+    let temp_dir = git_toprepo_testtools::test_util::maybe_keep_tempdir(
+        gix_testtools::scripted_fixture_writable(
+            "../integration/fixtures/make_minimal_with_two_submodules.sh",
+        )
+        .unwrap(),
+    );
+    let monorepo = temp_dir.join("mono");
+    let toprepo = temp_dir.join("top");
+
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    let worktree = temp_dir.join("worktree");
+    git_command_for_testing(temp_dir.join("mono"))
+        .args(["worktree", "add", "../worktree"])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&worktree)
+        .args(["recombine"])
+        .assert()
+        .success()
+        .stdout("");
+    assert!(std::fs::exists(monorepo.join(".git/toprepo/mono-refs-ok-to-remove")).unwrap());
+    assert!(!std::fs::exists(monorepo.join(".git/worktrees/worktree/toprepo")).unwrap());
+}
+
+#[test]
+fn push() {
+    let temp_dir = git_toprepo_testtools::test_util::maybe_keep_tempdir(
+        gix_testtools::scripted_fixture_writable(
+            "../integration/fixtures/make_minimal_with_two_submodules.sh",
+        )
+        .unwrap(),
+    );
+    let monorepo = temp_dir.join("mono");
+    let toprepo = temp_dir.join("top");
+
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    let worktree = temp_dir.join("worktree");
+    git_command_for_testing(temp_dir.join("mono"))
+        .args(["worktree", "add", "../worktree"])
+        .assert()
+        .success();
+
+    git_command_for_testing(&worktree)
+        .args([
+            "commit",
+            "--amend",
+            "-m",
+            "Message in worktree\n\nTopic: work",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&worktree)
+        .args(["push", "--dry-run", "origin", "HEAD:refs/dry/run"])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr(
+            predicate::str::is_match(
+                "INFO: Would run git push .*subx/ -o topic=work [0-9a-f]+:refs/dry/run\n",
+            )
+            .unwrap(),
+        )
+        .stderr(
+            predicate::str::is_match(
+                "INFO: Would run git push .*suby/ -o topic=work [0-9a-f]+:refs/dry/run\n",
+            )
+            .unwrap(),
+        )
+        .stderr(
+            predicate::str::is_match(
+                "INFO: Would run git push .*top -o topic=work [0-9a-f]+:refs/dry/run\n",
+            )
+            .unwrap(),
+        )
+        .stderr(predicate::function(|s: &str| {
+            s.matches("INFO: Would run git push").count() == 3
+        }));
 }


### PR DESCRIPTION
The refs are shared and stored in the main worktree. Therefore, it makes sense to also store all the git-toprepo caches there as they should be in sync with the refs.

Add tests for fetch, recombine and push in worktree. The recombine test triggered the error.

Fixes #71