### PR TITLE
Tidy 2025-10-02

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,9 @@
 style_edition = "2024"
 
+# Format string literals where necessary.
+# TODO: 2025-10-02 Add #[rustfmt::skip] to strings that should not be reformatted.
+format_strings = false
+
 # Format code snippet included in doc comments.
 format_code_in_doc_comments = true
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,8 @@
 style_edition = "2024"
 
+# Format code snippet included in doc comments.
+format_code_in_doc_comments = true
+
 # Discard existing import groups, and create a single group for everything.
 group_imports = "One"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -301,7 +301,7 @@ pub struct Recombine {
     /// Reuse information from the cache and skip combining the repositories
     /// from scratch.
     #[arg(long)]
-    pub reuse_cache: bool,
+    pub use_cache: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -314,9 +314,9 @@ pub struct Fetch {
     #[arg(long("jobs"), name = "N", default_value = "7")]
     pub job_count: std::num::NonZero<u16>,
 
-    /// Skip the filtering step after fetching the top repository.
+    /// Skip the combining history step after fetching the top repository.
     #[arg(long)]
-    pub skip_filter: bool,
+    pub skip_combine: bool,
 
     /// A configured git-remote in the mono repository, a URL to a remote top
     /// repository, a URL to a remote submodule repository, a working directory

--- a/src/commit_message.rs
+++ b/src/commit_message.rs
@@ -273,7 +273,6 @@ fn get_and_decode_commit_message(repo: &gix::Repository, commit_id: CommitId) ->
 }
 
 /// Best effort decoding the commit message, logging any error.
-///
 // TODO: 2025-09-22 How to only log at tips? Fix that later if an issue arises.
 fn decode_commit_message(commit: &gix::objs::CommitRef<'_>) -> String {
     let encoding = if let Some(encoding_name) = commit.encoding {
@@ -299,9 +298,9 @@ fn decode_commit_message(commit: &gix::objs::CommitRef<'_>) -> String {
 ///
 /// # Examples
 /// ```
-/// use git_toprepo::git::GitPath;
-/// use git_toprepo::commit_message::split_commit_message;
 /// use git_toprepo::commit_message::PushMessage;
+/// use git_toprepo::commit_message::split_commit_message;
+/// use git_toprepo::git::GitPath;
 ///
 /// let full_message = "\
 /// Subject line
@@ -327,7 +326,7 @@ fn decode_commit_message(commit: &gix::objs::CommitRef<'_>) -> String {
 /// ";
 /// let (messages, residual) = split_commit_message(full_message.to_owned()).unwrap();
 /// let expected_sub_push_message = PushMessage {
-///         message: "Subject line
+///     message: "Subject line
 ///
 /// Topic: not-the-footer-yet
 ///
@@ -335,24 +334,35 @@ fn decode_commit_message(commit: &gix::objs::CommitRef<'_>) -> String {
 /// Body line 2
 ///
 /// Footer-Key: value
-/// ".to_owned(),
-///         topic: Some("my-topic".to_owned()),
-///     };
-/// assert_eq!(messages, std::collections::HashMap::from_iter(vec![
-///     (GitPath::from("sub1"), expected_sub_push_message.clone()),
-///     (GitPath::from("sub2"), expected_sub_push_message),
-///     (GitPath::from(""), PushMessage {
-///        message: "Subject 2
+/// "
+///     .to_owned(),
+///     topic: Some("my-topic".to_owned()),
+/// };
+/// assert_eq!(
+///     messages,
+///     std::collections::HashMap::from_iter(vec![
+///         (GitPath::from("sub1"), expected_sub_push_message.clone()),
+///         (GitPath::from("sub2"), expected_sub_push_message),
+///         (
+///             GitPath::from(""),
+///             PushMessage {
+///                 message: "Subject 2
 ///
 /// Another-Footer: another value
-/// ".to_owned(),
-///        topic: None,
-///     }),
-/// ]));
-/// assert_eq!(residual, Some(PushMessage {
-///     message: "Residual message\n".to_owned(),
-///     topic: Some("with-topic".to_owned()),
-/// }));
+/// "
+///                 .to_owned(),
+///                 topic: None,
+///             }
+///         ),
+///     ])
+/// );
+/// assert_eq!(
+///     residual,
+///     Some(PushMessage {
+///         message: "Residual message\n".to_owned(),
+///         topic: Some("with-topic".to_owned()),
+///     })
+/// );
 /// ```
 pub fn split_commit_message(
     full_message: String,
@@ -631,19 +641,41 @@ fn is_interesting_message(message: &str) -> bool {
 /// use git_toprepo::commit_message::commit_message_has_footer;
 ///
 /// assert!(!commit_message_has_footer("Subject line".into()));
-/// assert!(!commit_message_has_footer("Subject line\nmore subject".into()));
-/// assert!(!commit_message_has_footer("Subject line\n\nBody (invalid footer line)\n".into()));
-/// assert!(!commit_message_has_footer("Subject line\n\nInvalid_Key: value\nValid-Key: value".into()));
+/// assert!(!commit_message_has_footer(
+///     "Subject line\nmore subject".into()
+/// ));
+/// assert!(!commit_message_has_footer(
+///     "Subject line\n\nBody (invalid footer line)\n".into()
+/// ));
+/// assert!(!commit_message_has_footer(
+///     "Subject line\n\nInvalid_Key: value\nValid-Key: value".into()
+/// ));
 ///
-/// assert!(commit_message_has_footer("Subject line\n\nFooter-Key: value".into()));
-/// assert!(!commit_message_has_footer("Subject line\n\nFooter Key: value".into()));
-/// assert!(commit_message_has_footer("Subject line\n\nBody\n\nFooter-Key: value".into()));
-/// assert!(!commit_message_has_footer("Subject line\n\nBody\n\nFooter Key: value".into()));
-/// assert!(commit_message_has_footer("Subject line\n\nFooter-Key: value\nAnother-Footer: another value".into()));
-/// assert!(!commit_message_has_footer("Subject line\n\nFooter Key: value\nAnother-Footer: value\n".into()));
+/// assert!(commit_message_has_footer(
+///     "Subject line\n\nFooter-Key: value".into()
+/// ));
+/// assert!(!commit_message_has_footer(
+///     "Subject line\n\nFooter Key: value".into()
+/// ));
+/// assert!(commit_message_has_footer(
+///     "Subject line\n\nBody\n\nFooter-Key: value".into()
+/// ));
+/// assert!(!commit_message_has_footer(
+///     "Subject line\n\nBody\n\nFooter Key: value".into()
+/// ));
+/// assert!(commit_message_has_footer(
+///     "Subject line\n\nFooter-Key: value\nAnother-Footer: another value".into()
+/// ));
+/// assert!(!commit_message_has_footer(
+///     "Subject line\n\nFooter Key: value\nAnother-Footer: value\n".into()
+/// ));
 ///
-/// assert!(!commit_message_has_footer("Subject line\n\nBad^Key: value".into()));
-/// assert!(!commit_message_has_footer("Subject line\n\nBad_Key: value".into()));
+/// assert!(!commit_message_has_footer(
+///     "Subject line\n\nBad^Key: value".into()
+/// ));
+/// assert!(!commit_message_has_footer(
+///     "Subject line\n\nBad_Key: value".into()
+/// ));
 /// ```
 pub fn commit_message_has_footer(message: &BStr) -> bool {
     let Some(footer_idx) = message.trim_end().rfind("\n\n") else {

--- a/src/expander.rs
+++ b/src/expander.rs
@@ -1333,20 +1333,32 @@ impl Default for BumpCache {
 /// }
 ///
 /// assert_eq!(
-///     strip_ref_prefix(&make_ref("refs/namespaces/top/refs/remotes/origin/foo"), "refs/namespaces/top/").unwrap(),
+///     strip_ref_prefix(
+///         &make_ref("refs/namespaces/top/refs/remotes/origin/foo"),
+///         "refs/namespaces/top/"
+///     )
+///     .unwrap(),
 ///     make_ref("refs/remotes/origin/foo"),
 /// );
 /// assert_eq!(
-///     strip_ref_prefix(&make_ref("refs/namespaces/top/HEAD"), "refs/namespaces/top/").unwrap(),
+///     strip_ref_prefix(
+///         &make_ref("refs/namespaces/top/HEAD"),
+///         "refs/namespaces/top/"
+///     )
+///     .unwrap(),
 ///     make_ref("HEAD"),
 /// );
 ///
 /// assert_eq!(
-///     strip_ref_prefix(&make_ref("refs/namespaces/top/HEAD"), "refs/namespaces/top").unwrap_err().to_string(),
+///     strip_ref_prefix(&make_ref("refs/namespaces/top/HEAD"), "refs/namespaces/top")
+///         .unwrap_err()
+///         .to_string(),
 ///     "A reference must be a valid tag name as well",
 /// );
 /// assert_eq!(
-///     strip_ref_prefix(&make_ref("refs/namespaces/top/HEAD"), "refs/other").unwrap_err().to_string(),
+///     strip_ref_prefix(&make_ref("refs/namespaces/top/HEAD"), "refs/other")
+///         .unwrap_err()
+///         .to_string(),
 ///     "Expected refs/namespaces/top/HEAD to start with refs/other",
 /// );
 /// ```

--- a/src/git.rs
+++ b/src/git.rs
@@ -71,7 +71,10 @@ impl GitPath {
     /// let bar = GitPath::from("bar");
     /// assert_eq!(foo_bar.relative_to(&foo), Some(GitPath::from("bar")));
     /// assert_eq!(foo_bar.relative_to(&foo_bar), Some(GitPath::from("")));
-    /// assert_eq!(foo_bar.relative_to(&empty_path), Some(GitPath::from("foo/bar")));
+    /// assert_eq!(
+    ///     foo_bar.relative_to(&empty_path),
+    ///     Some(GitPath::from("foo/bar"))
+    /// );
     /// assert_eq!(empty_path.relative_to(&bar), None);
     /// assert_eq!(foo_bar.relative_to(&bar), None);
     /// ```

--- a/src/gitmodules.rs
+++ b/src/gitmodules.rs
@@ -22,8 +22,9 @@ impl SubmoduleUrlExt for gix::url::Url {
     /// use gix::url;
     ///
     /// /// Join two URLs as strings.
-    /// fn join_url_str(base: &str, other: &str) -> String{
-    ///     gix::url::parse(base.as_bytes().as_bstr()).unwrap()
+    /// fn join_url_str(base: &str, other: &str) -> String {
+    ///     gix::url::parse(base.as_bytes().as_bstr())
+    ///         .unwrap()
     ///         .join(&gix::url::parse(other.as_bytes().as_bstr()).unwrap())
     ///         .to_string()
     /// }
@@ -76,14 +77,8 @@ impl SubmoduleUrlExt for gix::url::Url {
     ///     "file:///../foo",
     /// );
     /// // Without scheme.
-    /// assert_eq!(
-    ///     join_url_str("parent", "/data/repo"),
-    ///     "/data/repo",
-    /// );
-    /// assert_eq!(
-    ///     join_url_str("/data/repo", "../other"),
-    ///     "/data/other",
-    /// );
+    /// assert_eq!(join_url_str("parent", "/data/repo"), "/data/repo",);
+    /// assert_eq!(join_url_str("/data/repo", "../other"), "/data/other",);
     /// ```
     fn join(&self, other: &Self) -> Self {
         if other.scheme == gix::url::Scheme::File
@@ -258,12 +253,14 @@ pub fn join_relative_url_paths(base: &str, other: &str) -> String {
 ///     &mut outer_gitmodules.as_bytes().to_vec(),
 ///     gix::config::file::Metadata::default(),
 ///     Default::default(),
-/// ).unwrap();
+/// )
+/// .unwrap();
 /// let inner_config = gix::config::File::from_bytes_owned(
 ///     &mut inner_gitmodules.as_bytes().to_vec(),
 ///     gix::config::file::Metadata::default(),
 ///     Default::default(),
-/// ).unwrap();
+/// )
+/// .unwrap();
 /// git_toprepo::gitmodules::append_inner_submodule_config(
 ///     &mut outer_config,
 ///     &gix::url::parse(bstr::BStr::new(b"ssh://server.com/example/outer.git")).unwrap(),
@@ -273,8 +270,8 @@ pub fn join_relative_url_paths(base: &str, other: &str) -> String {
 /// let mut buf: Vec<u8> = Vec::new();
 /// outer_config.write_to(&mut buf).unwrap();
 /// assert_eq!(
-///    String::from_utf8(buf).unwrap(),
-///   r#"
+///     String::from_utf8(buf).unwrap(),
+///     r#"
 /// ## Comment that should be kept.
 /// [submodule "submod-outer"]
 ///     path = submod/outer
@@ -290,7 +287,8 @@ pub fn join_relative_url_paths(base: &str, other: &str) -> String {
 ///     url = ssh://server.com/inner.git
 ///     branch = .
 /// ## Another comment that should be kept.
-/// "#);
+/// "#
+/// );
 /// ```
 pub fn append_inner_submodule_config(
     config: &mut gix::config::File<'static>,

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -688,7 +688,7 @@ impl<'a> CommitLoader<'a> {
             };
             if result.is_ok() {
                 let fetch_duration = std::time::Instant::now().duration_since(start_time);
-                log::info!("git fetch {fetch_remote_str} completed in {fetch_duration:.0?}",);
+                log::info!("git fetch {fetch_remote_str} completed in {fetch_duration:.0?}");
             }
             // Sending might fail on interrupt.
             if let Err(err) = tx.send(TaskResult::RepoFetchDone {

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,7 @@ fn recombine(
     recombine_args: &cli::Recombine,
     configured_repo: &mut ConfiguredTopRepo,
 ) -> Result<()> {
-    if !recombine_args.reuse_cache {
+    if !recombine_args.use_cache {
         configured_repo.import_cache = ImportCache::default();
     }
     git_toprepo::log::get_global_logger().with_progress(|progress| {
@@ -400,7 +400,7 @@ fn fetch_with_default_refspecs(
                 keep_going: fetch_args.keep_going,
                 job_count: fetch_args.job_count,
                 no_fetch: false,
-                reuse_cache: true,
+                use_cache: true,
             },
             configured_repo,
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn clone_after_init(
         &cli::Fetch {
             keep_going: false,
             job_count: std::num::NonZero::new(1).unwrap(),
-            skip_filter: true,
+            skip_combine: true,
             remote: None,
             path: None,
             refspecs: None,
@@ -392,7 +392,7 @@ fn fetch_with_default_refspecs(
     fetcher.args.push("--prune".to_owned());
     fetch_on_terminal_with_duration_print(fetcher)?;
 
-    if !fetch_args.skip_filter {
+    if !fetch_args.skip_combine {
         // Reload the config from disk to get any changes fetched into the repository.
         configured_repo.reload_repo()?;
         recombine(
@@ -520,7 +520,7 @@ fn fetch_with_refspec(
             .collect_vec();
         fetch_on_terminal_with_duration_print(fetcher)?;
         // Stop early?
-        if fetch_args.skip_filter {
+        if fetch_args.skip_combine {
             return Ok(());
         }
         configured_repo.reload_repo()?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -250,8 +250,8 @@ where
     ///
     /// assert_eq!(Vec::<i32>::new().single_unique(), None);
     /// assert_eq!(vec![1].single_unique(), Some(1));
-    /// assert_eq!(vec![1,1,1].single_unique(), Some(1));
-    /// assert_eq!(vec![1,2,1].single_unique(), None);
+    /// assert_eq!(vec![1, 1, 1].single_unique(), Some(1));
+    /// assert_eq!(vec![1, 2, 1].single_unique(), None);
     /// ```
     fn single_unique(self) -> Option<T> {
         single_unique(self)
@@ -538,7 +538,6 @@ where
 /// # Examples
 /// ```
 /// use git_toprepo::util::is_default;
-///
 /// use serde::Serialize;
 /// #[derive(Serialize)]
 /// pub struct Config {

--- a/tests/integration/recombine.rs
+++ b/tests/integration/recombine.rs
@@ -553,7 +553,7 @@ missing_commits = [
         );
     cargo_bin_git_toprepo_for_testing()
         .current_dir(&monorepo)
-        .args(["recombine", "--reuse-cache"])
+        .args(["recombine", "--use-cache"])
         .assert()
         .success()
         .stdout("")
@@ -595,7 +595,7 @@ missing_commits = [
         );
     cargo_bin_git_toprepo_for_testing()
         .current_dir(&monorepo2)
-        .args(["recombine", "--reuse-cache"])
+        .args(["recombine", "--use-cache"])
         .assert()
         .success()
         .stdout("")


### PR DESCRIPTION
* tidy: Clarify `format_strings=false` in rustfmt.toml
* tidy: Remove comma
* tidy: Shorten `--reuse-cache` to `recombine --use-cache`
* tidy: Auto format code snippet included in doc comments
* tidy: Rename `--skip-filter` to `fetch --skip-combine`
