### PR TITLE
Allow configuration location fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,22 @@ of the configuration file is set in the `git-config` of the emulated mono reposi
 `git config --local toprepo.config <location>`
 and takes the following forms:
 
-* `repo:<ref>:<path>`, a path in the tree of git ref,
-* `local:<path>`, a file relative to the main worktree, and
-* `worktree:<path>`, a file relative to the current worktree.
+* `(may|should|must):repo:<ref>:<path>`, a path in the tree of git ref,
+* `(may|should|must):local:<path>`, a file relative to the main worktree, and
+* `(may|should|must):worktree:<path>`, a file relative to the current worktree.
+
+The last exising location specified in `git config --get-all toprepo.config` is used.
+
+The first keyword of the location specification describes the enforcement level,
+similarily to [IETF RFC 2119](https://www.ietf.org/rfc/rfc2119.txt):
+* `may`, warn if this configuration exists,
+* `should`, warn if this configuration is missing,
+* `must`, error if this configuration is missing and stop the search, which is
+  useful to avoid falling back from local to global git configuration.
 
 By default, the git-toprepo configuration is read from the committed `HEAD` in the remote toprepo,
-i.e. `repo:refs/namespaces/top/refs/remotes/origin/HEAD:.gittoprepo.toml`,
-but it is possible to override it with a local path.
+i.e. `should:refs/namespaces/top/refs/remotes/origin/HEAD:.gittoprepo.toml`,
+but prioritizes `may:worktree:.gittoprepo.user.toml` if it exists.
 
 ### Sub repositories
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -184,9 +184,14 @@ impl ConfiguredTopRepo {
         set_config(&[], "remote.origin.pruneTags", "false")?;
         set_config(&[], "submodule.recurse", "false")?;
         set_config(
-            &[],
+            &["--replace-all"],
             &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
-            &format!("repo:{toprepo_ref_prefix}refs/remotes/origin/HEAD:.gittoprepo.toml"),
+            &format!("should:repo:{toprepo_ref_prefix}refs/remotes/origin/HEAD:.gittoprepo.toml"),
+        )?;
+        set_config(
+            &["--add"],
+            &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),
+            "may:worktree:.gittoprepo.user.toml",
         )?;
 
         let result = {

--- a/src/util.rs
+++ b/src/util.rs
@@ -436,6 +436,8 @@ impl SafeOutput {
         if !self.status.success() {
             if self.stderr.is_empty() {
                 bail!("{}", self.status);
+            } else if !self.stderr.trim_ascii().contains(&b'\n') {
+                bail!("{}: {}", self.status, String::from_utf8_lossy(&self.stderr));
             } else {
                 bail!(
                     "{}:\n{}",

--- a/tests/integration/fetch.rs
+++ b/tests/integration/fetch.rs
@@ -590,7 +590,12 @@ fn timeout(
 
     let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
     git_command_for_testing(&repo.monorepo)
-        .args(["config", "toprepo.config", "local:.gittoprepo.toml"])
+        .args([
+            "config",
+            "--replace-all",
+            "toprepo.config",
+            "must:local:.gittoprepo.toml",
+        ])
         .assert()
         .success();
     let toprepo_config_path = repo.monorepo.join(".gittoprepo.toml");

--- a/tests/integration/fixtures/make_minimal_with_worktree.sh
+++ b/tests/integration/fixtures/make_minimal_with_worktree.sh
@@ -8,7 +8,7 @@ git -C from commit --allow-empty -m "init"
 git clone from mono
 cat <<EOF > mono/.gittoprepo.toml
 EOF
-git -C mono config --local toprepo.config local:.gittoprepo.toml
+git -C mono config --local toprepo.config must:local:.gittoprepo.toml
 
 # Cannot create a worktree in the cache because it includes an absolute path
 # that does not exist when the caching is done.


### PR DESCRIPTION
First trying to load `may:worktree:.gittoprepo.user.toml` is useful when needing a local configuration. It is also useful when bootstrapping and is missing from upstream.

Also add a bootstrap integration test.