### PR TITLE
Let config-bootstrap set fetch.url to current URL

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -389,8 +389,11 @@ impl SubRepoConfig {
         match &self.fetch.url {
             Some(url) => url,
             None => {
-                assert!(self.validate().is_ok());
-                &self.urls[0]
+                // More URLs might have been added during load, but keep using
+                // the first one, the only one that was loaded.
+                self.urls
+                    .first()
+                    .expect("at least one URL did exist when loading the config")
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,11 +250,18 @@ fn config_bootstrap(repo: &gix::Repository) -> Result<GitTopRepoConfig> {
                 .with_context(|| format!("Submodule {submod_path}"))
             {
                 Ok(Some(name)) => {
-                    repo.ledger
+                    let subrepo_ledger = repo
+                        .ledger
                         .subrepos
                         .get_mut(&name)
-                        .expect("valid subrepo name")
-                        .enabled = true
+                        .expect("valid subrepo name");
+                    subrepo_ledger.enabled = true;
+                    if subrepo_ledger.urls.len() != 1 {
+                        // Use the current URL in the config, the other URLs
+                        // must be from further back in the history and are
+                        // probably not valid any more.
+                        subrepo_ledger.fetch.url = Some(submod_url.clone());
+                    }
                 }
                 Ok(None) => unreachable!("Submodule {submod_path} should be in the config"),
                 Err(err) => {


### PR DESCRIPTION
Let `git-toprepo config bootstrap` perform better guessing about `fetch.url` for all the submodules, to simplify setting up a new configuration. The information in `.gitmodules` is probably what is wanted and everything earlier in the history should be disabled.