### PR TITLE
nix: use patchShebangs to fix integration tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,9 @@
               BUILD_SCM_TAG = "nix";
               BUILD_SCM_TIMESTAMP = fakeTimestamp;
               BUILD_SCM_REVISION = fakeRev;
+              patchPhase = ''
+                patchShebangs --build ./tests/integration/fixtures
+              '';
               nativeBuildInputs = with pkgs; [
                   git
                   python3


### PR DESCRIPTION
Changing file permissions to make fixture generation scripts executable broke the checkPhase in nix. This happened because gix-testtools assumes the scripts are executable commands and only tries to run them with bash if a script fails with a permission denied error.

https://docs.rs/crate/gix-testtools/0.16.1/source/src/lib.rs#581

In nix there's no /usr/bin/env available (which is required by the shebang) so therefore the scripts fail with a different error and gix-testtools fails the setup.

To fix this we patch the shebang lines of all test fixtures as recommended by nixpkgs:
https://github.com/NixOS/nixpkgs/issues/6227