### PR TITLE
Avoid `git checkout <branch>` tracking raw top repo branches

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -183,6 +183,11 @@ impl ConfiguredTopRepo {
         set_config(&[], "remote.origin.tagOpt", "--no-tags")?;
         set_config(&[], "remote.origin.pruneTags", "false")?;
         set_config(&[], "submodule.recurse", "false")?;
+        // Avoid `git checkout main` to start following
+        // `refs/namespaces/top/refs/remotes/origin/main` which `--guess`
+        // (default) does because it matches `remote.origin.fetch`. Instead, the
+        // user should run `git checkout -b main origin/main`.
+        set_config(&[], "checkout.guess", "false")?;
         set_config(
             &["--replace-all"],
             &toprepo_git_config(TOPREPO_CONFIG_FILE_KEY),


### PR DESCRIPTION
`git checkout <branch>` is looking at the `remote.origin.fetch` config to see if a ref that is matching the default fetch refspec exists. In that case, it checks that out and starts tracking it in the git-pull calls. With git-toprepo, the fetch refspec points to the original top commits, not the expanded mono commits, so unfiltered content is checked out and tracked when running `git pull`.

By setting `checkout.guess=false`, this automatic behaviour disappears.

An alternative solution is to create `git-remote-toprepo`, i.e. a new protocol to set as `remote.origin.url`. For fetch, that proxy can simply run 'recombine' afterwards. For push, it can split the mono commits before running the actual protocol. This does not work though when copying fetch commands from Gerrit because they include the original protocol.

An third alternative solution is to not store the refspecs in `remote.origin.fetch` at all but rather under
`toprepo.remote.origin.fetch`. Then `git fetch origin` can be totally disallowed and `git toprepo fetch` would just use the other values.