### PR TITLE
Add .git/hooks/pre-push for improved push error message

### DIFF
--- a/src/push.rs
+++ b/src/push.rs
@@ -680,6 +680,7 @@ impl PushTask {
         // Run the command.
         if !dry_run {
             let (mut proc, _span_guard) = git_command(self.context.toprepo.git_dir())
+                .env("GIT_TOPREPO_ALLOW_PUSH", "1")
                 .arg("push")
                 .arg(push_info.push_url.to_bstring().to_os_str()?)
                 .args(&extra_args)


### PR DESCRIPTION
The `pre-push` hook makes it possible to add a much more tidy error message about that `git-toprepo push` shall be used instead. It is not mandatory, so the user can easily replace it if wanted.