### PR TITLE
feat(push): add support for push options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -656,6 +656,10 @@ pub struct Push {
     #[arg(long, short = 'f')]
     pub force: bool,
 
+    /// Additional options to pass to the git push command.
+    #[arg(long = "push-option", short = 'o', value_name = "PUSH-OPTION")]
+    pub push_options: Vec<String>,
+
     /// A configured git remote in the mono repository or a URL of the top
     /// repository to push to. Submodules are calculated relative this remote.
     #[arg(value_name = "TOP-REMOTE")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -679,6 +679,13 @@ fn push(push_args: &cli::Push, configured_repo: &mut ConfiguredTopRepo) -> Resul
         extra_args.push("--force".to_owned());
     }
 
+    // Pass-through the push options to git push. This allows users to use features like
+    // `-o topic=name` and `-o description=desc` when pushing via AGit workflows.
+    push_args.push_options.iter().for_each(|option| {
+        extra_args.push("--push-option".to_owned());
+        extra_args.push(option.clone());
+    });
+
     let base_url = match configured_repo
         .gix_repo
         .try_find_remote(push_args.top_remote.as_bytes())

--- a/tests/integration/push.rs
+++ b/tests/integration/push.rs
@@ -701,6 +701,157 @@ fn force_push() {
         .stderr(predicate::str::contains(" -> other (forced update)"));
 }
 
+#[test]
+fn push_option_single() {
+    let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
+    let toprepo = temp_dir.join("top");
+    let monorepo = temp_dir.join("mono");
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    std::fs::write(monorepo.join("file.txt"), "top\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "file.txt"])
+        .assert()
+        .success();
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Add file\n\nTopic: my-topic"])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&monorepo)
+        .args([
+            "push",
+            "origin",
+            "--push-option",
+            "review=my-review-id",
+            "HEAD:refs/heads/foo",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "\nremote: GIT_PUSH_OPTION_0=review=my-review-id",
+        ))
+        .stderr(predicate::str::contains(
+            "\nremote: GIT_PUSH_OPTION_1=topic=my-topic",
+        ));
+}
+
+#[test]
+fn push_option_short_form() {
+    let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
+    let toprepo = temp_dir.join("top");
+    let monorepo = temp_dir.join("mono");
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    std::fs::write(monorepo.join("file.txt"), "top\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "file.txt"])
+        .assert()
+        .success();
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Add file"])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&monorepo)
+        .args([
+            "push",
+            "origin",
+            "-o",
+            "description=my-desc",
+            "HEAD:refs/heads/foo",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "\nremote: GIT_PUSH_OPTION_0=description=my-desc",
+        ));
+
+    git_command_for_testing(&toprepo)
+        .args(["show", "refs/heads/foo:file.txt"])
+        .assert()
+        .success()
+        .stdout("top\n");
+}
+
+#[test]
+fn push_option_multiple() {
+    let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
+    let toprepo = temp_dir.join("top");
+    let monorepo = temp_dir.join("mono");
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    std::fs::write(monorepo.join("file.txt"), "top\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "file.txt"])
+        .assert()
+        .success();
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Add file\n\nTopic: my-topic"])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&monorepo)
+        .args([
+            "push",
+            "origin",
+            "-o",
+            "key1=val1",
+            "-o",
+            "key2=val2",
+            "HEAD:refs/heads/foo",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "\nremote: GIT_PUSH_OPTION_0=key1=val1",
+        ))
+        .stderr(predicate::str::contains(
+            "\nremote: GIT_PUSH_OPTION_1=key2=val2",
+        ))
+        .stderr(predicate::str::contains(
+            "\nremote: GIT_PUSH_OPTION_2=topic=my-topic",
+        ));
+}
+
+#[test]
+fn push_option_dry_run() {
+    let temp_dir = crate::fixtures::toprepo::readme_example_tempdir();
+    let toprepo = temp_dir.join("top");
+    let monorepo = temp_dir.join("mono");
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    std::fs::write(monorepo.join("file.txt"), "top\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "file.txt"])
+        .assert()
+        .success();
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Add file"])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&monorepo)
+        .args([
+            "push",
+            "origin",
+            "--dry-run",
+            "--push-option",
+            "my-opt=my-val",
+            "HEAD:refs/heads/foo",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_match(
+            "INFO: Would run git push .* --push-option my-opt=my-val [0-9a-f]+:refs/heads/foo\n",
+        )
+        .unwrap());
+}
+
 /// The following push error message from a Gerrit server should be ignored:
 /// ```text
 /// ! [remote rejected] HEAD -> refs/for/something (no new changes)


### PR DESCRIPTION
Add --push-option and -o flags to pass additional options to git push, enabling features like topic and description setting for AGit workflows. Includes implementation in CLI parsing and push execution, plus comprehensive tests for single, multiple, short form, and dry run scenarios.

This is useful for i.e. Forgejo instances, which have support for AGit style workflows, where force-push, title and description can be "pushed" through the push-option(s).

# References
Git docs:
* https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionoption

Forgejo docs:
* https://forgejo.org/docs/next/user/agit-support/

