### PR TITLE
feat(push): Extract topic from Gerrit-style refspec for push operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,18 @@ default.
 
 #### git toprepo push
 `git toprepo push` splits the commits and runs `git push` towards each needed
-remote repository. If the monocommit spans multiple repositories, git-toprepo
-adds the push option `topic=` according to the `Topic:` written in the commit
-message footer.
+remote repository. When the monocommit spans multiple repositories, a topic is
+required so that Gerrit can submit the changes atomically.
+
+The topic can be provided in two ways:
+
+* **Refspec** (Gerrit/AGit workflow): push to a refspec that encodes the topic,
+  such as `HEAD:refs/for/branch/my-topic` or `HEAD:refs/for/branch%topic=my-topic`.
+  Gerrit reads the topic directly from the refspec, so no additional push option
+  is needed.
+* **Commit message footer**: add a `Topic: <name>` footer line to the commit
+  message. git-toprepo strips the footer before pushing and communicates the
+  topic via the `topic=` push option.
 
 When amending a commit, the committer date changes, but the content to be pushed
 might stay the same for some target repositories. To avoid pushing commits where
@@ -462,10 +471,12 @@ On the client side, a few commit message footers are used. They are removed when
 splitting mono commits, before pushing to any remote.
 
 * `Topic: \<global-name\>` can be used to create a topic for one or multiple monocommits.
-  This will not be pushed in the commit to the Gerrit backend.
-  Other review system backends,
-  when they are implemented,
-  may need to keep this footer.
+  The footer is stripped before pushing and the topic is communicated via the
+  `topic=` push option. Alternatively, the topic can be encoded in the refspec
+  (e.g. `refs/for/branch/my-topic` or `refs/for/branch%topic=my-topic`),
+  in which case no push option is emitted since Gerrit reads the topic from the
+  refspec itself. Other review system backends, when they are implemented, may
+  need to keep this footer.
 
   The topic footer is also be written back during when combining the git
   histories.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -665,8 +665,9 @@ pub struct Push {
     #[arg(value_name = "TOP-REMOTE")]
     pub top_remote: String,
 
-    /// A reference to push from the top repository. Refspec wildcards are not
-    /// supported.
+    /// A reference to push from the top repository. The refspec is propagated
+    /// as-is, so topic names like `refs/for/main/topic-name` are supported.
+    /// Refspec wildcards are not supported.
     #[arg(value_name = "REFSPEC", required=true, num_args=1.., value_parser = clap::builder::ValueParser::new(parse_refspec))]
     pub refspecs: Vec<(String, String)>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -706,13 +706,21 @@ fn push(push_args: &cli::Push, configured_repo: &mut ConfiguredTopRepo) -> Resul
         unimplemented!("Handle multiple refspecs");
     };
     // TODO: 2025-09-22 This assumes a single ref in the refspec. What about patterns?
+    // Extract Gerrit topic from the refspec (e.g. %topic=my-topic or /my-topic).
+    // Used for validation only; the refspec already communicates the topic to Gerrit.
+    let refspec_topic = git_toprepo::push::extract_push_topic(remote_ref);
     let remote_ref = FullName::try_from(remote_ref.as_bytes().as_bstr())
         .with_context(|| format!("Bad remote ref {remote_ref}"))?;
     let local_rev = local_ref;
 
     git_toprepo::log::get_global_logger().with_progress(|progress| {
-        let commits =
-            git_toprepo::push::split_for_push(configured_repo, &progress, &base_url, local_rev)?;
+        let commits = git_toprepo::push::split_for_push(
+            configured_repo,
+            &progress,
+            &base_url,
+            local_rev,
+            refspec_topic,
+        )?;
         ErrorObserver::run_keep_going(!push_args.fail_fast, |error_observer| {
             let commit_pusher = git_toprepo::push::CommitPusher::new(
                 configured_repo.gix_repo.clone(),

--- a/src/push.rs
+++ b/src/push.rs
@@ -46,6 +46,7 @@ pub fn split_for_push(
     progress: &indicatif::MultiProgress,
     top_push_url: &gix::Url,
     local_rev_or_ref: &String,
+    refspec_topic: Option<String>,
 ) -> Result<Vec<PushData>> {
     if configured_repo.import_cache.monorepo_commits.is_empty() {
         anyhow::bail!("No filtered mono commits exists, please run `git toprepo recombine` first");
@@ -86,6 +87,7 @@ pub fn split_for_push(
         &mut fast_importer,
         top_push_url,
         export_refs_args,
+        refspec_topic,
     );
     // Make sure to gracefully shutdown the fast-importer before returning.
     fast_importer.wait()?;
@@ -193,6 +195,7 @@ fn split_for_push_impl(
     fast_importer: &mut crate::git_fast_export_import_dedup::FastImportRepoDedup<'_>,
     top_push_url: &gix::Url,
     export_refs_args: Vec<std::ffi::OsString>,
+    refspec_topic: Option<String>,
 ) -> Result<Vec<PushData>> {
     enum SplitParent {
         Mono(Rc<MonoRepoCommit>),
@@ -347,9 +350,9 @@ fn split_for_push_impl(
                     );
                 }
             };
-            if !single_push && subrepo_message.topic.is_none() {
+            if !single_push && subrepo_message.topic.is_none() && refspec_topic.is_none() {
                 anyhow::bail!(
-                    r#"Multiple submodules are modified in commit {mono_commit_id} "{0}", but no topic was provided. Please amend the commit message to add a 'Topic: something-descriptive' footer line."#,
+                    r#"Multiple submodules are modified in commit {mono_commit_id} "{0}", but no topic was provided. Please push to a Gerrit refspec like refs/for/branch/topic-name or amend the commit message to add a 'Topic: something-descriptive' footer line."#,
                     subrepo_message
                         .subject_and_body
                         .lines()
@@ -771,5 +774,79 @@ impl Drop for PushTask {
             .push_progress
             .inc_queue_size(-(self.reversed_push_metadata.len() as isize));
         drop(self.current_push_item.take());
+    }
+}
+
+/// Extracts the topic from a Gerrit-style refspec.
+///
+/// Handles two topic sources:
+/// - URL-encoded: `refs/for/master%topic=my-topic` or `refs/for/master%t=short`
+/// - Path-based: `refs/for/master/my-topic`
+///
+/// The extracted topic is used for validation only (checking that a topic exists
+/// for multi-submodule commits). The `-o topic=` push option is emitted only when
+/// the topic comes from the commit message `Topic:` footer, not from the refspec.
+///
+/// `%topic=` takes precedence over path-based `/TOPIC`.
+pub fn extract_push_topic(remote_ref: &str) -> Option<String> {
+    // Check URL-encoded push options (e.g. %topic=foo,hashtag=bar).
+    if let Some((_ref_part, options)) = remote_ref.split_once('%') {
+        let topic = options.split(',').find_map(|opt| {
+            opt.strip_prefix("topic=")
+                .or_else(|| opt.strip_prefix("t="))
+        });
+        if let Some(topic) = topic {
+            return Some(topic.to_owned());
+        }
+    }
+    // Extract path-based topic from refs/for/<branch>/<topic>.
+    extract_topic_from_path(remote_ref)
+}
+
+fn extract_topic_from_path(ref_str: &str) -> Option<String> {
+    let stripped = ref_str.strip_prefix("refs/for/")?;
+    let mut segments = stripped.split('/');
+    segments.next()?;
+    let topic = segments.collect::<Vec<_>>().join("/");
+    if topic.is_empty() { None } else { Some(topic) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_gerrit_style_topic_from_url() {
+        assert_eq!(
+            extract_push_topic("refs/for/master%topic=my-topic"),
+            Some("my-topic".to_owned())
+        );
+        assert_eq!(
+            extract_push_topic("refs/for/master%topic=driver/i42,hashtag=fix"),
+            Some("driver/i42".to_owned())
+        );
+        assert_eq!(
+            extract_push_topic("refs/for/master%t=short"),
+            Some("short".to_owned())
+        );
+        assert_eq!(extract_push_topic("refs/for/master%hashtag=fix"), None);
+    }
+
+    #[test]
+    fn extract_gerrit_style_topic_from_path() {
+        assert_eq!(
+            extract_push_topic("refs/for/master/TOPIC"),
+            Some("TOPIC".to_owned())
+        );
+        assert_eq!(
+            extract_push_topic("refs/for/release/1.0/TOPIC"),
+            Some("1.0/TOPIC".to_owned())
+        );
+    }
+
+    #[test]
+    fn extract_gerrit_style_topic_none() {
+        assert_eq!(extract_push_topic("refs/for/master"), None);
+        assert_eq!(extract_push_topic("refs/heads/master"), None);
     }
 }

--- a/tests/integration/push.rs
+++ b/tests/integration/push.rs
@@ -520,7 +520,235 @@ fn topic_is_required_for_multi_repo_push() {
         .code(1);
     insta::assert_snapshot!(
         cmd.get_output().stderr.to_str().unwrap(),
-                @r#"ERROR: Multiple submodules are modified in commit 068408a74b19b6d4c260af0cc109d2c0c475f7d5 "Add files", but no topic was provided. Please amend the commit message to add a 'Topic: something-descriptive' footer line."#
+                @r#"ERROR: Multiple submodules are modified in commit 068408a74b19b6d4c260af0cc109d2c0c475f7d5 "Add files", but no topic was provided. Please push to a Gerrit refspec like refs/for/branch/topic-name or amend the commit message to add a 'Topic: something-descriptive' footer line."#
+    );
+}
+
+/// When pushing to a Gerrit-style refspec like `refs/for/master/TOPIC`, the topic
+/// is extracted from the refspec path for validation. No `-o topic=` is emitted
+/// since Gerrit already reads the topic from the refspec.
+#[test]
+fn topic_extracted_from_gerrit_refspec() {
+    let temp_dir = git_toprepo_testtools::test_util::maybe_keep_tempdir(
+        gix_testtools::scripted_fixture_writable(
+            "../integration/fixtures/make_minimal_with_two_submodules.sh",
+        )
+        .unwrap(),
+    );
+    let monorepo = temp_dir.join("mono");
+    let toprepo = temp_dir.join("top");
+
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+    std::fs::write(monorepo.join("top.txt"), "top\n").unwrap();
+    std::fs::write(monorepo.join("subpathx/file.txt"), "subx\n").unwrap();
+    std::fs::write(monorepo.join("subpathy/file.txt"), "suby\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "top.txt", "subpathx/file.txt", "subpathy/file.txt"])
+        .assert()
+        .success();
+    // No Topic: footer — the topic comes from the refspec, no -o needed.
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Add files"])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&monorepo)
+        .args([
+            "push",
+            "--jobs=1",
+            "--dry-run",
+            "origin",
+            "HEAD:refs/for/master/my-topic",
+        ])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr(
+            predicate::str::is_match(
+                "INFO: Would run git push .*repox/ [0-9a-f]+:refs/for/master/my-topic\n",
+            )
+            .unwrap(),
+        )
+        .stderr(
+            predicate::str::is_match(
+                "INFO: Would run git push .*repoy/ [0-9a-f]+:refs/for/master/my-topic\n",
+            )
+            .unwrap(),
+        )
+        .stderr(
+            predicate::str::is_match(
+                "INFO: Would run git push .*top [0-9a-f]+:refs/for/master/my-topic\n",
+            )
+            .unwrap(),
+        )
+        .stderr(predicate::str::contains("-o topic=").not());
+}
+
+/// When pushing with Gerrit `%topic=` syntax, the topic is extracted for validation
+/// and the `%topic=...` suffix is preserved in the refspec. No `-o topic=` is emitted
+/// since Gerrit reads the topic from the `%topic=` in the refspec.
+#[test]
+fn topic_extracted_from_gerrit_push_option_in_refspec() {
+    let temp_dir = git_toprepo_testtools::test_util::maybe_keep_tempdir(
+        gix_testtools::scripted_fixture_writable(
+            "../integration/fixtures/make_minimal_with_two_submodules.sh",
+        )
+        .unwrap(),
+    );
+    let monorepo = temp_dir.join("mono");
+    let toprepo = temp_dir.join("top");
+
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+    std::fs::write(monorepo.join("top.txt"), "top\n").unwrap();
+    std::fs::write(monorepo.join("subpathx/file.txt"), "subx\n").unwrap();
+    std::fs::write(monorepo.join("subpathy/file.txt"), "suby\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "top.txt", "subpathx/file.txt", "subpathy/file.txt"])
+        .assert()
+        .success();
+    // No Topic: footer — the topic comes from %topic= in the refspec, no -o needed.
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Add files"])
+        .assert()
+        .success();
+
+    // The %topic= suffix is preserved in the refspec; Gerrit reads the topic from it.
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&monorepo)
+        .args([
+            "push",
+            "--jobs=1",
+            "--dry-run",
+            "origin",
+            "HEAD:refs/for/master%topic=pct-topic",
+        ])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr(
+            predicate::str::is_match(
+                "INFO: Would run git push .*repox/ [0-9a-f]+:refs/for/master%topic=pct-topic\n",
+            )
+            .unwrap(),
+        )
+        .stderr(
+            predicate::str::is_match(
+                "INFO: Would run git push .*repoy/ [0-9a-f]+:refs/for/master%topic=pct-topic\n",
+            )
+            .unwrap(),
+        )
+        .stderr(
+            predicate::str::is_match(
+                "INFO: Would run git push .*top [0-9a-f]+:refs/for/master%topic=pct-topic\n",
+            )
+            .unwrap(),
+        )
+        .stderr(predicate::str::contains("-o topic=").not());
+}
+
+#[test]
+fn topic_priority_across_commits() {
+    let temp_dir = git_toprepo_testtools::test_util::maybe_keep_tempdir(
+        gix_testtools::scripted_fixture_writable(
+            "../integration/fixtures/make_minimal_with_two_submodules.sh",
+        )
+        .unwrap(),
+    );
+    let monorepo = temp_dir.join("mono");
+    let toprepo = temp_dir.join("top");
+
+    crate::fixtures::toprepo::clone(&toprepo, &monorepo);
+
+    // Commit A: no Topic footer -> uses refspec %topic=messaging
+    std::fs::write(monorepo.join("top.txt"), "A\n").unwrap();
+    std::fs::write(monorepo.join("subpathx/file.txt"), "A\n").unwrap();
+    std::fs::write(monorepo.join("subpathy/file.txt"), "A\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "top.txt", "subpathx/file.txt", "subpathy/file.txt"])
+        .assert()
+        .success();
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Commit A"])
+        .assert()
+        .success();
+
+    // Commit B: Topic: web -> footer wins over refspec %topic=messaging
+    std::fs::write(monorepo.join("top.txt"), "B\n").unwrap();
+    std::fs::write(monorepo.join("subpathx/file.txt"), "B\n").unwrap();
+    std::fs::write(monorepo.join("subpathy/file.txt"), "B\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "top.txt", "subpathx/file.txt", "subpathy/file.txt"])
+        .assert()
+        .success();
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Commit B\n\nTopic: web"])
+        .assert()
+        .success();
+
+    // Commit C: Topic: rpc -> footer wins over refspec %topic=messaging
+    std::fs::write(monorepo.join("top.txt"), "C\n").unwrap();
+    std::fs::write(monorepo.join("subpathx/file.txt"), "C\n").unwrap();
+    std::fs::write(monorepo.join("subpathy/file.txt"), "C\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "top.txt", "subpathx/file.txt", "subpathy/file.txt"])
+        .assert()
+        .success();
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Commit C\n\nTopic: rpc"])
+        .assert()
+        .success();
+
+    // Commit D: no Topic footer -> uses refspec %topic=messaging
+    std::fs::write(monorepo.join("top.txt"), "D\n").unwrap();
+    std::fs::write(monorepo.join("subpathx/file.txt"), "D\n").unwrap();
+    std::fs::write(monorepo.join("subpathy/file.txt"), "D\n").unwrap();
+    git_command_for_testing(&monorepo)
+        .args(["add", "top.txt", "subpathx/file.txt", "subpathy/file.txt"])
+        .assert()
+        .success();
+    git_command_for_testing(&monorepo)
+        .args(["commit", "-m", "Commit D"])
+        .assert()
+        .success();
+
+    let result = cargo_bin_git_toprepo_for_testing()
+        .current_dir(&monorepo)
+        .args([
+            "push",
+            "--jobs=1",
+            "--dry-run",
+            "origin",
+            "HEAD:refs/for/master%topic=messaging",
+        ])
+        .assert()
+        .success();
+
+    let stderr = &result.get_output().stderr;
+    let stderr_str = String::from_utf8_lossy(stderr);
+
+    // 4 commits × 3 repos = 12 pushes total.
+    // A and D have no Topic footer -> no -o topic= (topic from refspec %topic=messaging).
+    // B has Topic: web -> -o topic=web (3 pushes).
+    // C has Topic: rpc -> -o topic=rpc (3 pushes).
+    let count_topic = |output: &str, topic: &str| {
+        let pattern = format!("-o topic={topic}");
+        output.matches(&pattern).count()
+    };
+    assert_eq!(
+        count_topic(&stderr_str, "messaging"),
+        0,
+        "expected 0 pushes with -o topic=messaging (refspec topic not repeated as -o):\n{stderr_str}"
+    );
+    assert_eq!(
+        count_topic(&stderr_str, "web"),
+        3,
+        "expected 3 pushes with topic=web (commit B, 3 repos):\n{stderr_str}"
+    );
+    assert_eq!(
+        count_topic(&stderr_str, "rpc"),
+        3,
+        "expected 3 pushes with topic=rpc (commit C, 3 repos):\n{stderr_str}"
     );
 }
 


### PR DESCRIPTION
When working with a larger codebase, it's common to push commits across submodules (i.e. backend + webui changes). As there will be many of them, it is inconvenient to step over the dev-branch and append the Topic: to each commit.

[Gerrit code review](https://gerrit-review.googlesource.com/Documentation/concept-refs-for-namespace.html) uses the refs/for/<branch> namespace for review pushes. Gerrit supports associating a [topic](https://gerrit-review.googlesource.com/Documentation/user-upload.html#topic) with a push via either %topic= in the refspec URL or -o topic=<name> as a [push option](https://gerrit-review.googlesource.com/Documentation/user-upload.html).

This PR adds the ability to extract the topic name from the target refspec, either %topic, or %t or the AGit-style that Forgejo/Gitea support.

If this is not the correct direction, I'm happy to look into implementing alternative approaches.