### PR TITLE
Feat/fetch lfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ use `git toprepo config bootstrap` afterwards to create one.
 
 `git toprepo fetch [<remote>]` fetches from a `remote` and performs the submodule expansion.
 
+`git toprepo lfs fetch [OPTIONS] <PATH>...` routes each monorepo path to the
+correct repository remote and runs `git lfs fetch` with path includes.
+This avoids fetching LFS objects from the wrong remote when working in an
+emulated monorepo.
+
 `git toprepo push [-n/--dry-run] <remote> <rev>:<ref> ...` does a submodule split
 so that each submodule is pushed to its respective upstream repository.
 If running with `-n` or `--dry-run`, the resulting `git push` command lines
@@ -46,6 +51,7 @@ operations acting on the local git repository stay the same.
 | `git init`                     | `git toprepo init`                                              |
 | `git clone`                    | `git toprepo clone`                                             |
 | `git fetch`                    | `git toprepo fetch`[*](#git-toprepo-fetch)                      |
+| `git lfs fetch`                | `git toprepo lfs fetch`[*](#git-toprepo-lfs-fetch)              |
 | `git push`                     | `git toprepo push`[*](#git-toprepo-push)                        |
 | `git pull`                     | `git toprepo fetch && git rebase/merge`[*](#branch-tracking)    |
 | `git checkout origin/<branch>` | `git checkout origin/<branch>`                                  |
@@ -73,6 +79,35 @@ there is no ancestor that have been expanded into a monocommit.
 
 Note that `--tags` is not supported. All tags are fetched and expanded by
 default.
+
+#### git toprepo lfs fetch
+`git toprepo lfs fetch` is a path-aware wrapper around `git lfs fetch`.
+For each input path, git-toprepo resolves the owning repository using
+`.gitmodules` + `.gittoprepo.toml`, then runs `git lfs fetch <remote> -I <path>`.
+
+Basic usage:
+
+* `git toprepo lfs fetch path/to/file.bin`
+* `git toprepo lfs fetch subrepo/a.bin subrepo/b.bin`
+* `git toprepo lfs fetch --dry-run path/to/file.bin`
+* `git toprepo lfs fetch --prune --recent --refetch path/to/file.bin`
+* `git toprepo lfs fetch -X "*.tmp" path/to/file.bin`
+
+Notes and constraints:
+
+* `git lfs` must be installed and working (`git lfs version`).
+* Paths are treated as literal paths (glob-like path arguments are rejected).
+* Relative paths are accepted, including from subdirectories.
+* Nested submodules use the deepest matching submodule path.
+* If a submodule URL from `.gitmodules` is not configured in `.gittoprepo.toml`,
+  the command fails instead of falling back to a wrong remote.
+* Unsupported flags are rejected: `--all`, `--stdin`, `--include/-I`, `--json`.
+  (`-I` is managed internally by git-toprepo.)
+
+The integration tests cover these behaviors, including top-level routing,
+subrepo routing, relative path handling, deepest-match routing, unsupported
+flag rejection, and clear failures when `git lfs` is missing or config is
+incomplete.
 
 #### git toprepo push
 `git toprepo push` splits the commits and runs `git push` towards each needed

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ use `git toprepo config bootstrap` afterwards to create one.
 
 `git toprepo lfs fetch [OPTIONS] <PATH>...` routes each monorepo path to the
 correct repository remote and runs `git lfs fetch` with path includes.
-This avoids fetching LFS objects from the wrong remote when working in an
-emulated monorepo.
 
 `git toprepo push [-n/--dry-run] <remote> <rev>:<ref> ...` does a submodule split
 so that each submodule is pushed to its respective upstream repository.
@@ -100,7 +98,7 @@ Notes and constraints:
 * Relative paths are accepted, including from subdirectories.
 * Nested submodules use the deepest matching submodule path.
 * If a submodule URL from `.gitmodules` is not configured in `.gittoprepo.toml`,
-  the command fails instead of falling back to a wrong remote.
+  the command fails.
 * Unsupported flags are rejected: `--all`, `--stdin`, `--include/-I`, `--json`.
   (`-I` is managed internally by git-toprepo.)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -226,6 +226,10 @@ pub struct LfsFetch {
     #[arg(long = "exclude", short = 'X', value_name = "PATHS")]
     pub exclude: Vec<String>,
 
+    /// Monorepo path(s) whose LFS objects should be fetched.
+    #[arg(value_name = "PATH", required = true)]
+    pub paths: Vec<PathBuf>,
+
     /// Unsupported in git-toprepo's LFS wrapper.
     #[arg(long, hide = true)]
     pub all: bool,
@@ -242,9 +246,6 @@ pub struct LfsFetch {
     #[arg(long, hide = true)]
     pub json: bool,
 
-    /// Monorepo path(s) whose LFS objects should be fetched.
-    #[arg(value_name = "PATH", required = true)]
-    pub paths: Vec<PathBuf>,
 }
 
 impl LfsFetch {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -193,6 +193,78 @@ pub enum Commands {
     /// Print the version of the git-toprepo tool.
     #[command(aliases = ["-V", "--version"])]
     Version,
+    /// Git LFS helpers for emulated monorepos.
+    #[command(subcommand)]
+    Lfs(Lfs),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Lfs {
+    /// Fetch LFS objects for monorepo paths.
+    Fetch(LfsFetch),
+}
+
+#[derive(Args, Debug)]
+pub struct LfsFetch {
+    /// Print what Git LFS would fetch, without downloading objects.
+    #[arg(long, short = 'd')]
+    pub dry_run: bool,
+
+    /// Prune old and unreferenced LFS objects after fetching.
+    #[arg(long, short = 'p')]
+    pub prune: bool,
+
+    /// Also fetch recent LFS objects according to Git LFS recent settings.
+    #[arg(long)]
+    pub recent: bool,
+
+    /// Fetch objects even if they already exist locally.
+    #[arg(long)]
+    pub refetch: bool,
+
+    /// Exclude paths for this invocation.
+    #[arg(long = "exclude", short = 'X', value_name = "PATHS")]
+    pub exclude: Vec<String>,
+
+    /// Unsupported in git-toprepo's LFS wrapper.
+    #[arg(long, hide = true)]
+    pub all: bool,
+
+    /// Unsupported in git-toprepo's LFS wrapper.
+    #[arg(long, hide = true)]
+    pub stdin: bool,
+
+    /// Unsupported in git-toprepo's LFS wrapper.
+    #[arg(long, short = 'I', hide = true, value_name = "PATHS")]
+    pub include: Vec<String>,
+
+    /// Unsupported in git-toprepo's LFS wrapper.
+    #[arg(long, hide = true)]
+    pub json: bool,
+
+    /// Monorepo path(s) whose LFS objects should be fetched.
+    #[arg(value_name = "PATH", required = true)]
+    pub paths: Vec<PathBuf>,
+}
+
+impl LfsFetch {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.all {
+            anyhow::bail!("`--all` is unsupported for `git toprepo lfs fetch`");
+        }
+        if self.stdin {
+            anyhow::bail!("`--stdin` is unsupported for `git toprepo lfs fetch`");
+        }
+        if !self.include.is_empty() {
+            anyhow::bail!(
+                "`--include`/`-I` is unsupported for `git toprepo lfs fetch`; git-toprepo supplies `-I` internally"
+            );
+        }
+        if self.json {
+            anyhow::bail!("`--json` is unsupported for `git toprepo lfs fetch`");
+        }
+        Ok(())
+    }
 }
 
 #[derive(Args, Debug)]

--- a/src/lfs.rs
+++ b/src/lfs.rs
@@ -187,6 +187,8 @@ Git's long-running filter process can take precedence over filter.lfs.smudge, so
 }
 
 fn default_fetch_url(repo: &gix::Repository) -> Result<gix::Url> {
+    // NB: find_default_remote() returns Option<Result<Remote, Error>>;
+    // the first context handles None, the second handles Err.
     Ok(repo
         .find_default_remote(gix::remote::Direction::Fetch)
         .context("Default git-remote not found")?

--- a/src/lfs.rs
+++ b/src/lfs.rs
@@ -1,0 +1,427 @@
+use crate::git::GitModulesInfo;
+use crate::git::GitPath;
+use crate::gitmodules::SubmoduleUrlExt as _;
+use crate::log::CommandSpanExt as _;
+use crate::repo::ConfiguredTopRepo;
+use crate::repo_name::RepoName;
+use crate::util::CommandExtension as _;
+use anyhow::Context as _;
+use anyhow::Result;
+use anyhow::bail;
+use bstr::ByteSlice as _;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+
+const LFS_SMUDGE_KEY: &str = "filter.lfs.smudge";
+const LFS_PROCESS_KEY: &str = "filter.lfs.process";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LfsFetchTarget {
+    pub include_path: GitPath,
+    pub repo_name: RepoName,
+    pub remote_url: gix::Url,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LfsFetchOptions {
+    pub dry_run: bool,
+    pub prune: bool,
+    pub recent: bool,
+    pub refetch: bool,
+    pub exclude: Vec<String>,
+}
+
+pub fn is_lfs_filter_through_toprepo(command: &str, subcommand: &str) -> bool {
+    let tokens: Vec<&str> = command.split_whitespace().collect();
+    if tokens.is_empty() {
+        return false;
+    }
+    let subcommand = subcommand.to_ascii_lowercase();
+    let command_name = Path::new(tokens[0])
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(tokens[0]);
+    let matches_git_toprepo = |tokens: &[&str]| {
+        tokens.len() >= 2
+            && command_name.eq_ignore_ascii_case("git-toprepo")
+            && tokens[1].eq_ignore_ascii_case("lfs")
+            && tokens
+                .get(2)
+                .is_some_and(|cmd| cmd.eq_ignore_ascii_case(&subcommand))
+    };
+    if matches_git_toprepo(&tokens) {
+        return true;
+    }
+    if tokens.len() >= 3
+        && tokens[0].eq_ignore_ascii_case("git")
+        && tokens[1].eq_ignore_ascii_case("toprepo")
+        && tokens[2].eq_ignore_ascii_case("lfs")
+        && tokens
+            .get(3)
+            .is_some_and(|cmd| cmd.eq_ignore_ascii_case(&subcommand))
+    {
+        return true;
+    }
+    false
+}
+
+pub fn ensure_git_lfs_available(repo_worktree: &Path) -> Result<()> {
+    let status = Command::new("git")
+        .args(["lfs", "version"])
+        .current_dir(repo_worktree)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .trace_command(crate::command_span!("git lfs version"))
+        .safe_status();
+    match status {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => bail!(
+            "Git LFS is required for `git toprepo lfs fetch`, but `git lfs version` failed.\n\
+Install Git LFS and ensure `git lfs version` works.\n\
+Status: {status}"
+        ),
+        Err(err) => bail!(
+            "Git LFS is required for `git toprepo lfs fetch`, but `git lfs version` failed.\n\
+Install Git LFS and ensure `git lfs version` works.\n\
+Error: {err}"
+        ),
+    }
+}
+
+pub fn warn_if_lfs_filters_bypass_toprepo(repo: &gix::Repository) -> Result<()> {
+    warn_if_lfs_filter_bypass_toprepo(repo.git_dir(), LFS_SMUDGE_KEY, "smudge")?;
+    warn_if_lfs_filter_bypass_toprepo(repo.git_dir(), LFS_PROCESS_KEY, "filter-process")?;
+    Ok(())
+}
+
+pub fn resolve_lfs_fetch_targets(
+    top_repo: &ConfiguredTopRepo,
+    paths: &[PathBuf],
+) -> Result<Vec<LfsFetchTarget>> {
+    let worktree = top_repo
+        .gix_repo
+        .workdir()
+        .context("Worktree missing in git repository")?;
+    let worktree = normalize_path(worktree);
+    let top_url = default_fetch_url(&top_repo.gix_repo)?;
+    let gitmodules = GitModulesInfo::parse_dot_gitmodules_in_repo(&top_repo.gix_repo)?;
+
+    paths
+        .iter()
+        .map(|path| {
+            ensure_literal_path(path)?;
+            let include_path = repo_relative_git_path(&worktree, path)?;
+            resolve_lfs_target_for_path(top_repo, &gitmodules, &top_url, include_path)
+        })
+        .collect()
+}
+
+pub fn run_lfs_fetch(
+    worktree: &Path,
+    targets: &[LfsFetchTarget],
+    options: &LfsFetchOptions,
+) -> Result<()> {
+    for target in targets {
+        let remote_url = target.remote_url.to_bstring().to_str()?.to_owned();
+        let mut cmd = Command::new("git");
+        cmd.arg("lfs").arg("fetch").arg(remote_url);
+        if options.dry_run {
+            cmd.arg("--dry-run");
+        }
+        if options.prune {
+            cmd.arg("--prune");
+        }
+        if options.recent {
+            cmd.arg("--recent");
+        }
+        if options.refetch {
+            cmd.arg("--refetch");
+        }
+        for exclude in &options.exclude {
+            cmd.arg("-X").arg(exclude);
+        }
+        cmd.arg("-I").arg(target.include_path.to_string());
+        cmd.current_dir(worktree)
+            .trace_command(crate::command_span!("git lfs fetch"))
+            .safe_status()?
+            .check_success()
+            .with_context(|| format!("`git lfs fetch` failed for `{}`", target.include_path))?;
+    }
+    Ok(())
+}
+
+fn warn_if_lfs_filter_bypass_toprepo(repo: &Path, key: &str, subcommand: &str) -> Result<()> {
+    for value in crate::git::git_config_get_all(repo, key)? {
+        if !is_lfs_filter_through_toprepo(&value, subcommand) {
+            match subcommand {
+                "smudge" => log::warn!(
+                    "warning: {key} is configured as `{value}`, which bypasses git-toprepo.\n\
+In an emulated monorepo this may fetch LFS objects from the wrong remote. Configure the LFS smudge filter to go through git-toprepo when using git-toprepo LFS support."
+                ),
+                "filter-process" => log::warn!(
+                    "warning: {key} is configured as `{value}`, which bypasses git-toprepo.\n\
+Git's long-running filter process can take precedence over filter.lfs.smudge, so this may bypass git-toprepo-aware LFS handling."
+                ),
+                _ => unreachable!(),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn default_fetch_url(repo: &gix::Repository) -> Result<gix::Url> {
+    Ok(repo
+        .find_default_remote(gix::remote::Direction::Fetch)
+        .context("Default git-remote not found")?
+        .context("Bad default git-remote")?
+        .url(gix::remote::Direction::Fetch)
+        .context("Missing fetch URL for the default git-remote")?
+        .clone())
+}
+
+fn resolve_lfs_target_for_path(
+    top_repo: &ConfiguredTopRepo,
+    gitmodules: &GitModulesInfo,
+    top_url: &gix::Url,
+    include_path: GitPath,
+) -> Result<LfsFetchTarget> {
+    let Some((submodule_path, submodule_url)) =
+        deepest_containing_submodule(gitmodules, &include_path)
+    else {
+        return Ok(LfsFetchTarget {
+            include_path,
+            repo_name: RepoName::Top,
+            remote_url: top_url.clone(),
+        });
+    };
+
+    let submodule_url = submodule_url
+        .as_ref()
+        .map_err(|err| anyhow::anyhow!("Bad URL for {submodule_path} in .gitmodules: {err}"))?
+        .clone();
+    let resolved_url = top_url.join(&submodule_url);
+    let repo_name = match top_repo
+        .ledger
+        .get_name_from_similar_full_url(resolved_url.clone(), top_url)
+    {
+        Ok(RepoName::SubRepo(repo_name))
+            if !top_repo.ledger.missing_subrepos.contains(&repo_name) =>
+        {
+            repo_name
+        }
+        Ok(_) | Err(_) => {
+            bail!(
+                "Cannot resolve LFS remote for `{include_path}`.\n\
+The path belongs to submodule `{submodule_path}`, but its .gitmodules URL is not configured in .gittoprepo.toml."
+            )
+        }
+    };
+
+    Ok(LfsFetchTarget {
+        include_path,
+        repo_name: RepoName::from(repo_name),
+        remote_url: resolved_url,
+    })
+}
+
+fn deepest_containing_submodule<'a>(
+    gitmodules: &'a GitModulesInfo,
+    path: &GitPath,
+) -> Option<(&'a GitPath, &'a Result<gix::Url>)> {
+    let mut best = None;
+    let mut best_len = 0usize;
+    for (submodule_path, url) in &gitmodules.submodules {
+        if path.relative_to(submodule_path).is_some() && submodule_path.len() >= best_len {
+            best = Some((submodule_path, url));
+            best_len = submodule_path.len();
+        }
+    }
+    best
+}
+
+fn ensure_literal_path(path: &Path) -> Result<()> {
+    let path = path.to_string_lossy();
+    if path.contains('*') || path.contains('?') || path.contains('[') || path.contains(']') {
+        bail!(
+            "`git toprepo lfs fetch` currently expects literal paths, not glob patterns: `{path}`"
+        );
+    }
+    Ok(())
+}
+
+fn repo_relative_git_path(worktree: &Path, path: &Path) -> Result<GitPath> {
+    let cwd = std::env::current_dir().context("Failed to get current directory")?;
+    let cwd = normalize_path(&cwd);
+    let requested = if path.is_absolute() {
+        normalize_path(path)
+    } else {
+        normalize_path(&cwd.join(path))
+    };
+    let rel = requested
+        .strip_prefix(worktree)
+        .with_context(|| format!("Path `{}` is outside the worktree", path.display()))?;
+    Ok(path_to_git_path(rel))
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
+}
+
+#[cfg(unix)]
+fn path_to_git_path(path: &Path) -> GitPath {
+    GitPath::from(path.as_os_str().as_encoded_bytes())
+}
+
+#[cfg(windows)]
+fn path_to_git_path(path: &Path) -> GitPath {
+    GitPath::from(path.to_string_lossy().replace('\\', "/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SubRepoConfig;
+    use crate::repo_name::SubRepoName;
+    use bstr::BStr;
+
+    #[test]
+    fn accepts_git_toprepo_wrapper() {
+        assert!(is_lfs_filter_through_toprepo(
+            "git-toprepo lfs smudge -- %f",
+            "smudge"
+        ));
+        assert!(is_lfs_filter_through_toprepo(
+            "git toprepo lfs filter-process",
+            "filter-process"
+        ));
+        assert!(is_lfs_filter_through_toprepo(
+            "/some/path/git-toprepo lfs smudge -- %f",
+            "smudge"
+        ));
+    }
+
+    #[test]
+    fn rejects_plain_git_lfs() {
+        assert!(!is_lfs_filter_through_toprepo(
+            "git-lfs smudge -- %f",
+            "smudge"
+        ));
+        assert!(!is_lfs_filter_through_toprepo(
+            "git lfs filter-process",
+            "filter-process"
+        ));
+    }
+
+    #[test]
+    fn deepest_prefix_wins() {
+        let mut gitmodules = GitModulesInfo::default();
+        gitmodules.submodules.insert(
+            GitPath::from("libs/a"),
+            Ok(gix::Url::from_bytes(b"../a.git".as_bstr()).unwrap()),
+        );
+        gitmodules.submodules.insert(
+            GitPath::from("libs/a/vendor/b"),
+            Ok(gix::Url::from_bytes(b"../b.git".as_bstr()).unwrap()),
+        );
+        let hit =
+            deepest_containing_submodule(&gitmodules, &GitPath::from("libs/a/vendor/b/model.bin"))
+                .map(|(path, _)| path.clone())
+                .unwrap();
+        assert_eq!(hit, GitPath::from("libs/a/vendor/b"));
+    }
+
+    #[test]
+    fn repo_relative_path_rejects_outside_worktree() {
+        let worktree = normalize_path(Path::new("/tmp/worktree"));
+        let err = repo_relative_git_path(&worktree, Path::new("../outside"))
+            .expect_err("path should be rejected");
+        assert!(err.to_string().contains("outside the worktree"));
+    }
+
+    #[test]
+    fn resolves_top_level_path_to_top_repo() {
+        let repo = init_repo();
+        let target =
+            resolve_lfs_fetch_targets(&repo, &[repo.gix_repo.workdir().unwrap().join("video.mov")])
+                .unwrap();
+        assert_eq!(target[0].repo_name, RepoName::Top);
+        assert_eq!(target[0].include_path, GitPath::from("video.mov"));
+    }
+
+    fn init_repo() -> ConfiguredTopRepo {
+        let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+        git_toprepo_testtools::test_util::git_command_for_testing(&temp_dir)
+            .args(["init"])
+            .assert()
+            .success();
+        git_toprepo_testtools::test_util::git_command_for_testing(&temp_dir)
+            .args([
+                "config",
+                "remote.origin.url",
+                "ssh://example.com/toprepo.git",
+            ])
+            .assert()
+            .success();
+        std::fs::write(
+            temp_dir.join(".gitmodules"),
+            "[submodule \"service-a\"]\n\tpath = service-a\n\turl = ../service-a.git\n",
+        )
+        .unwrap();
+        let mut repo = ConfiguredTopRepo::new_empty(gix::open(temp_dir.path()).unwrap());
+        let subrepo_url =
+            gix::Url::from_bytes(BStr::new("ssh://example.com/service-a.git".as_bytes())).unwrap();
+        repo.config.subrepos.insert(
+            SubRepoName::new("service-a".to_owned()),
+            SubRepoConfig::new_disabled(subrepo_url.clone()),
+        );
+        repo.ledger.subrepos = repo.config.subrepos.clone();
+        repo
+    }
+
+    #[test]
+    fn resolves_submodule_path_to_subrepo_url() {
+        let repo = init_repo();
+        let mut gitmodules = GitModulesInfo::default();
+        gitmodules.submodules.insert(
+            GitPath::from("service-a"),
+            Ok(gix::Url::from_bytes(b"../service-a.git".as_bstr()).unwrap()),
+        );
+        assert_eq!(
+            deepest_containing_submodule(
+                &gitmodules,
+                &GitPath::from("service-a/assets/model.bin"),
+            )
+            .map(|(path, _)| path.clone()),
+            Some(GitPath::from("service-a"))
+        );
+        let top_url = default_fetch_url(&repo.gix_repo).unwrap();
+        let target = resolve_lfs_target_for_path(
+            &repo,
+            &gitmodules,
+            &top_url,
+            GitPath::from("service-a/assets/model.bin"),
+        )
+        .unwrap();
+        assert_eq!(target.repo_name.to_string(), "service-a");
+        assert_eq!(
+            target.include_path,
+            GitPath::from("service-a/assets/model.bin")
+        );
+    }
+}

--- a/src/lfs.rs
+++ b/src/lfs.rs
@@ -68,34 +68,25 @@ pub fn is_lfs_filter_through_toprepo(command: &str, subcommand: &str) -> bool {
     false
 }
 
+const GIT_LFS_REQUIRED: &str = "\
+Git LFS is required for `git toprepo lfs fetch`.
+Install Git LFS and ensure `git-lfs version` works.
+Underlying error";
+
 pub fn ensure_git_lfs_available(repo_worktree: &Path) -> Result<()> {
-    let status = Command::new("git")
-        .args(["lfs", "version"])
+    Command::new("git-lfs")
+        .arg("version")
         .current_dir(repo_worktree)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .trace_command(crate::command_span!("git lfs version"))
-        .safe_status();
-    match status {
-        Ok(status) if status.success() => Ok(()),
-        Ok(status) => {
-            log::info!("Use: `sudo apt install git-lfs`");
-            bail!(
-                "Git LFS is required for `git toprepo lfs fetch`, but `git lfs version` failed.\n\
-Install Git LFS and ensure `git lfs version` works.\n\
-Status: {status}"
-            )
-        },
-        Err(err) => {
-            log::info!("Use: `sudo apt install git-lfs`");
-            bail!(
-                "Git LFS is required for `git toprepo lfs fetch`, but `git lfs version` failed.\n\
-Install Git LFS and ensure `git lfs version` works.\n\
-Error: {err}"
-            )
-        },
-    }
+        .trace_command(crate::command_span!("git-lfs version"))
+        .safe_status()
+        .context(GIT_LFS_REQUIRED)?
+        .check_success()
+        .context(GIT_LFS_REQUIRED)?;
+
+    Ok(())
 }
 
 pub fn warn_if_lfs_filters_bypass_toprepo(repo: &gix::Repository) -> Result<()> {
@@ -133,8 +124,10 @@ pub fn run_lfs_fetch(
 ) -> Result<()> {
     for target in targets {
         let remote_url = target.remote_url.to_bstring().to_str()?.to_owned();
-        let mut cmd = Command::new("git");
-        cmd.arg("lfs").arg("fetch").arg(remote_url);
+
+        let mut cmd = Command::new("git-lfs");
+        cmd.arg("fetch").arg(&remote_url);
+
         if options.dry_run {
             cmd.arg("--dry-run");
         }
@@ -147,16 +140,30 @@ pub fn run_lfs_fetch(
         if options.refetch {
             cmd.arg("--refetch");
         }
+
         for exclude in &options.exclude {
-            cmd.arg("-X").arg(exclude);
+            cmd.arg(format!("--exclude={exclude}"));
         }
-        cmd.arg("-I").arg(target.include_path.to_string());
+
+        cmd.arg(format!("--include={}", target.include_path));
+
         cmd.current_dir(worktree)
-            .trace_command(crate::command_span!("git lfs fetch"))
+            .trace_command(crate::command_span!("git-lfs fetch"))
             .safe_status()?
             .check_success()
-            .with_context(|| format!("`git lfs fetch` failed for `{}`", target.include_path))?;
+            .with_context(|| {
+                if options.dry_run {
+                    format!(
+                        "`git-lfs fetch --dry-run` failed for `{}`. \
+Your installed Git LFS version may not support `--dry-run`.",
+                        target.include_path
+                    )
+                } else {
+                    format!("`git-lfs fetch` failed for `{}`", target.include_path)
+                }
+            })?;
     }
+
     Ok(())
 }
 

--- a/src/lfs.rs
+++ b/src/lfs.rs
@@ -79,16 +79,22 @@ pub fn ensure_git_lfs_available(repo_worktree: &Path) -> Result<()> {
         .safe_status();
     match status {
         Ok(status) if status.success() => Ok(()),
-        Ok(status) => bail!(
-            "Git LFS is required for `git toprepo lfs fetch`, but `git lfs version` failed.\n\
+        Ok(status) => {
+            log::info!("Use: `sudo apt install git-lfs`");
+            bail!(
+                "Git LFS is required for `git toprepo lfs fetch`, but `git lfs version` failed.\n\
 Install Git LFS and ensure `git lfs version` works.\n\
 Status: {status}"
-        ),
-        Err(err) => bail!(
-            "Git LFS is required for `git toprepo lfs fetch`, but `git lfs version` failed.\n\
+            )
+        },
+        Err(err) => {
+            log::info!("Use: `sudo apt install git-lfs`");
+            bail!(
+                "Git LFS is required for `git toprepo lfs fetch`, but `git lfs version` failed.\n\
 Install Git LFS and ensure `git lfs version` works.\n\
 Error: {err}"
-        ),
+            )
+        },
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod git_fast_export_import;
 pub mod git_fast_export_import_dedup;
 pub mod gitmodules;
 pub mod import_cache_serde;
+pub mod lfs;
 pub mod loader;
 pub mod log;
 pub mod push;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use colored::Colorize;
 use git_toprepo::config::ConfigLocation;
 use git_toprepo::config::GitTopRepoConfig;
 use git_toprepo::git::GitModulesInfo;
+use git_toprepo::lfs;
 use git_toprepo::log::CommandSpanExt as _;
 use git_toprepo::log::ErrorMode;
 use git_toprepo::log::ErrorObserver;
@@ -322,6 +323,7 @@ fn recombine(
 
 #[tracing::instrument(skip(configured_repo))]
 fn fetch(fetch_args: &cli::Fetch, configured_repo: &mut ConfiguredTopRepo) -> Result<()> {
+    lfs::warn_if_lfs_filters_bypass_toprepo(&configured_repo.gix_repo)?;
     if let Some(refspecs) = &fetch_args.refspecs {
         let resolved_args = cli::resolve_remote_and_path(
             fetch_args,
@@ -1014,6 +1016,26 @@ where
         Commands::Fetch(fetch_args) => {
             run_session(logger, |configured| fetch(fetch_args, configured))
                 .map(|()| ExitCode::SUCCESS)
+        }
+        Commands::Lfs(cli::Lfs::Fetch(fetch_args)) => {
+            fetch_args.validate()?;
+            run_session(logger, |configured| {
+                let worktree = configured
+                    .gix_repo
+                    .workdir()
+                    .context("Worktree missing in git repository")?;
+                lfs::ensure_git_lfs_available(worktree)?;
+                let targets = lfs::resolve_lfs_fetch_targets(configured, &fetch_args.paths)?;
+                let options = lfs::LfsFetchOptions {
+                    dry_run: fetch_args.dry_run,
+                    prune: fetch_args.prune,
+                    recent: fetch_args.recent,
+                    refetch: fetch_args.refetch,
+                    exclude: fetch_args.exclude.clone(),
+                };
+                lfs::run_lfs_fetch(worktree, &targets, &options)
+            })
+            .map(|()| ExitCode::SUCCESS)
         }
         Commands::Push(push_args) => run_session(logger, |configured| push(push_args, configured))
             .map(|()| ExitCode::SUCCESS),

--- a/tests/integration/fetch.rs
+++ b/tests/integration/fetch.rs
@@ -7,7 +7,7 @@ use predicates::prelude::*;
 use rstest::rstest;
 use std::path::Path;
 
-struct RepoWithTwoSubmodules {
+pub(crate) struct RepoWithTwoSubmodules {
     pub toprepo: std::path::PathBuf,
     pub monorepo: std::path::PathBuf,
     pub subx_repo: std::path::PathBuf,
@@ -18,7 +18,7 @@ struct RepoWithTwoSubmodules {
 }
 
 impl RepoWithTwoSubmodules {
-    pub fn new_minimal_with_two_submodules() -> Self {
+    pub(crate) fn new_minimal_with_two_submodules() -> Self {
         let temp_dir_guard = git_toprepo_testtools::test_util::maybe_keep_tempdir(
             gix_testtools::scripted_fixture_writable(
                 "../integration/fixtures/make_minimal_with_two_submodules.sh",
@@ -811,4 +811,88 @@ fn unaffected_by_dot_gitmodules_recurse_true() {
             )
             .unwrap(),
         );
+}
+
+#[test]
+fn warns_when_lfs_smudge_bypasses_toprepo() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    git_command_for_testing(&repo.monorepo)
+        .args(["config", "filter.lfs.smudge", "git-lfs smudge -- %f"])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["fetch", "--skip-combine"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("filter.lfs.smudge"))
+        .stderr(predicate::str::contains("bypasses git-toprepo"));
+}
+
+#[test]
+fn does_not_warn_when_lfs_smudge_uses_toprepo() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    git_command_for_testing(&repo.monorepo)
+        .args([
+            "config",
+            "filter.lfs.smudge",
+            "git-toprepo lfs smudge -- %f",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["fetch", "--skip-combine"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("filter.lfs.smudge").not());
+}
+
+#[test]
+fn does_not_warn_when_lfs_smudge_uses_git_toprepo_subcommand_form() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    git_command_for_testing(&repo.monorepo)
+        .args([
+            "config",
+            "filter.lfs.smudge",
+            "git toprepo lfs smudge -- %f",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["fetch", "--skip-combine"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("filter.lfs.smudge").not());
+}
+
+#[test]
+fn warns_when_lfs_process_bypasses_toprepo() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    git_command_for_testing(&repo.monorepo)
+        .args([
+            "config",
+            "filter.lfs.smudge",
+            "git-toprepo lfs smudge -- %f",
+        ])
+        .assert()
+        .success();
+    git_command_for_testing(&repo.monorepo)
+        .args(["config", "filter.lfs.process", "git-lfs filter-process"])
+        .assert()
+        .success();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["fetch", "--skip-combine"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("filter.lfs.process"))
+        .stderr(predicate::str::contains(
+            "bypass git-toprepo-aware LFS handling",
+        ));
 }

--- a/tests/integration/lfs.rs
+++ b/tests/integration/lfs.rs
@@ -1,0 +1,362 @@
+use super::fetch::RepoWithTwoSubmodules;
+use bstr::ByteSlice as _;
+use git_toprepo::gitmodules::SubmoduleUrlExt as _;
+use git_toprepo_testtools::test_util::cargo_bin_git_toprepo_for_testing;
+use git_toprepo_testtools::test_util::git_command_for_testing;
+use predicates::prelude::*;
+use std::ffi::OsString;
+use std::path::Path;
+use std::path::PathBuf;
+
+struct RepoWithInnerSubmodule {
+    monorepo: PathBuf,
+    #[expect(unused)]
+    temp_dir_guard: git_toprepo_testtools::test_util::MaybePermanentTempDir,
+}
+
+impl RepoWithInnerSubmodule {
+    fn new() -> Self {
+        let temp_dir_guard = git_toprepo_testtools::test_util::maybe_keep_tempdir(
+            gix_testtools::scripted_fixture_writable(
+                "../integration/fixtures/make_minimal_with_inner_submodule.sh",
+            )
+            .unwrap(),
+        );
+        let temp_dir = temp_dir_guard.canonicalize().unwrap();
+        let monorepo = temp_dir.join("mono");
+        crate::fixtures::toprepo::clone(&temp_dir.join("top"), &monorepo);
+        Self {
+            monorepo,
+            temp_dir_guard,
+        }
+    }
+}
+
+fn make_fake_git_lfs(dir: &Path, version_exit: i32) -> std::path::PathBuf {
+    let path = dir.join("git-lfs");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "git-lfs/FAKE"
+  exit {version_exit}
+fi
+if [ "$1" = "fetch" ]; then
+  remote=$2
+  shift 2
+  printf 'cwd=%s\n' "$(pwd)" >> "$GIT_TOPREPO_TEST_LFS_LOG"
+  printf 'remote=%s\n' "$remote" >> "$GIT_TOPREPO_TEST_LFS_LOG"
+  for arg in "$@"; do
+    printf 'arg=%s\n' "$arg" >> "$GIT_TOPREPO_TEST_LFS_LOG"
+  done
+  exit "${{GIT_TOPREPO_TEST_LFS_EXIT:-0}}"
+fi
+echo "unexpected git-lfs command: $*" >&2
+exit 64
+"#
+    );
+    std::fs::write(&path, script).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+    }
+    path
+}
+
+fn prepend_path(bin_dir: &Path) -> OsString {
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![bin_dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&old_path));
+    std::env::join_paths(paths).unwrap()
+}
+
+fn log_contents(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_default()
+}
+
+#[test]
+fn missing_git_lfs_fails_clearly() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+    let bin_dir = temp_dir.path();
+    make_fake_git_lfs(bin_dir, 1);
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["lfs", "fetch", "subpathx/assets/model.bin"])
+        .env("PATH", prepend_path(bin_dir))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Git LFS is required for `git toprepo lfs fetch`",
+        ))
+        .stderr(predicate::str::contains("git lfs version"))
+        .stderr(predicate::str::contains("Install Git LFS"));
+}
+
+#[test]
+fn fetches_top_level_path_from_top_repo_url() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+    let bin_dir = temp_dir.path();
+    let log_path = bin_dir.join("lfs.log");
+    make_fake_git_lfs(bin_dir, 0);
+
+    let top_url = git_command_for_testing(&repo.monorepo)
+        .args(["config", "--get", "remote.origin.url"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .to_str()
+        .unwrap()
+        .trim()
+        .to_owned();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["lfs", "fetch", "video.mov"])
+        .env("GIT_TOPREPO_TEST_LFS_LOG", &log_path)
+        .env("PATH", prepend_path(bin_dir))
+        .assert()
+        .success();
+
+    let log = log_contents(&log_path);
+    assert!(log.contains(&format!("cwd={}\n", repo.monorepo.display())));
+    assert!(log.contains(&format!("remote={top_url}")));
+    assert!(log.contains("arg=-I"));
+    assert!(log.contains("arg=video.mov"));
+}
+
+#[test]
+fn fetches_subrepo_path_from_subrepo_url() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+    let bin_dir = temp_dir.path();
+    let log_path = bin_dir.join("lfs.log");
+    make_fake_git_lfs(bin_dir, 0);
+
+    let top_url = git_command_for_testing(&repo.monorepo)
+        .args(["config", "--get", "remote.origin.url"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .to_str()
+        .unwrap()
+        .trim()
+        .to_owned();
+    let submodule_url = git_command_for_testing(&repo.monorepo)
+        .args([
+            "config",
+            "--file",
+            ".gitmodules",
+            "--get",
+            "submodule.subpathx.url",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .to_str()
+        .unwrap()
+        .trim()
+        .to_owned();
+    let expected_remote = gix::Url::from_bytes(top_url.as_bytes().as_bstr())
+        .unwrap()
+        .join(&gix::Url::from_bytes(submodule_url.as_bytes().as_bstr()).unwrap())
+        .to_string();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["lfs", "fetch", "subpathx/assets/model.bin"])
+        .env("GIT_TOPREPO_TEST_LFS_LOG", &log_path)
+        .env("PATH", prepend_path(bin_dir))
+        .assert()
+        .success();
+
+    let log = log_contents(&log_path);
+    assert!(log.contains(&format!("remote={expected_remote}")));
+    assert!(log.contains("arg=-I"));
+    assert!(log.contains("arg=subpathx/assets/model.bin"));
+}
+
+#[test]
+fn fetches_relative_path_from_subdirectory() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+    let bin_dir = temp_dir.path();
+    let log_path = bin_dir.join("lfs.log");
+    make_fake_git_lfs(bin_dir, 0);
+    std::fs::create_dir_all(repo.monorepo.join("subpathx")).unwrap();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(repo.monorepo.join("subpathx"))
+        .args(["lfs", "fetch", "assets/model.bin"])
+        .env("GIT_TOPREPO_TEST_LFS_LOG", &log_path)
+        .env("PATH", prepend_path(bin_dir))
+        .assert()
+        .success();
+
+    let log = log_contents(&log_path);
+    assert!(log.contains("cwd="));
+    assert!(log.contains("arg=subpathx/assets/model.bin"));
+}
+
+#[test]
+fn fetches_multiple_paths_one_by_one() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+    let bin_dir = temp_dir.path();
+    let log_path = bin_dir.join("lfs.log");
+    make_fake_git_lfs(bin_dir, 0);
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["lfs", "fetch", "subpathx/a.bin", "subpathy/b.bin"])
+        .env("GIT_TOPREPO_TEST_LFS_LOG", &log_path)
+        .env("PATH", prepend_path(bin_dir))
+        .assert()
+        .success();
+
+    let log = log_contents(&log_path);
+    assert!(log.matches("cwd=").count() == 2);
+    assert!(log.contains("arg=subpathx/a.bin"));
+    assert!(log.contains("arg=subpathy/b.bin"));
+}
+
+#[test]
+fn rejects_all_option() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+    let bin_dir = temp_dir.path();
+    make_fake_git_lfs(bin_dir, 0);
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["lfs", "fetch", "--all", "subpathx/file.bin"])
+        .env("PATH", prepend_path(bin_dir))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`--all` is unsupported for `git toprepo lfs fetch`",
+        ));
+}
+
+#[test]
+fn errors_on_unconfigured_subrepo() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+    let bin_dir = temp_dir.path();
+    let log_path = bin_dir.join("lfs.log");
+    make_fake_git_lfs(bin_dir, 0);
+
+    git_command_for_testing(&repo.monorepo)
+        .args([
+            "config",
+            "--replace-all",
+            "toprepo.config",
+            "must:local:.gittoprepo.toml",
+        ])
+        .assert()
+        .success();
+    std::fs::write(
+        repo.monorepo.join(".gittoprepo.toml"),
+        "[repo.namey]\nurl = \"../repoy/\"\n",
+    )
+    .unwrap();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["lfs", "fetch", "subpathx/file.bin"])
+        .env("GIT_TOPREPO_TEST_LFS_LOG", &log_path)
+        .env("PATH", prepend_path(bin_dir))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Cannot resolve LFS remote for `subpathx/file.bin`",
+        ))
+        .stderr(predicate::str::contains("belongs to submodule `subpathx`"))
+        .stderr(predicate::str::contains(
+            "not configured in .gittoprepo.toml",
+        ));
+
+    assert!(log_contents(&log_path).is_empty());
+}
+
+#[test]
+fn uses_deepest_matching_submodule_path() {
+    let repo = RepoWithInnerSubmodule::new();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+    let bin_dir = temp_dir.path();
+    let log_path = bin_dir.join("lfs.log");
+    make_fake_git_lfs(bin_dir, 0);
+
+    let top_url = git_command_for_testing(&repo.monorepo)
+        .args(["config", "--get", "remote.origin.url"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .to_str()
+        .unwrap()
+        .trim()
+        .to_owned();
+    let inner_url = git_command_for_testing(&repo.monorepo)
+        .args([
+            "config",
+            "--file",
+            ".gitmodules",
+            "--get",
+            "submodule.subpathx.url",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .to_str()
+        .unwrap()
+        .trim()
+        .to_owned();
+    let expected_remote = gix::Url::from_bytes(top_url.as_bytes().as_bstr())
+        .unwrap()
+        .join(&gix::Url::from_bytes(inner_url.as_bytes().as_bstr()).unwrap())
+        .to_string();
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["lfs", "fetch", "subpathx/subpathy/model.bin"])
+        .env("GIT_TOPREPO_TEST_LFS_LOG", &log_path)
+        .env("PATH", prepend_path(bin_dir))
+        .assert()
+        .success();
+
+    let log = log_contents(&log_path);
+    assert!(log.contains(&format!("remote={expected_remote}")));
+    assert!(log.contains("arg=subpathx/subpathy/model.bin"));
+}
+
+#[test]
+fn preserves_spaces_in_include_path() {
+    let repo = RepoWithTwoSubmodules::new_minimal_with_two_submodules();
+    let temp_dir = git_toprepo_testtools::test_util::MaybePermanentTempDir::create();
+    let bin_dir = temp_dir.path();
+    let log_path = bin_dir.join("lfs.log");
+    make_fake_git_lfs(bin_dir, 0);
+
+    cargo_bin_git_toprepo_for_testing()
+        .current_dir(&repo.monorepo)
+        .args(["lfs", "fetch", "subpathx/assets/big file.bin"])
+        .env("GIT_TOPREPO_TEST_LFS_LOG", &log_path)
+        .env("PATH", prepend_path(bin_dir))
+        .assert()
+        .success();
+
+    let log = log_contents(&log_path);
+    assert!(
+        log.lines()
+            .any(|line| line == "arg=subpathx/assets/big file.bin")
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -14,6 +14,8 @@ mod fetch;
 mod info;
 #[cfg(test)]
 mod init;
+#[cfg(all(test, unix))]
+mod lfs;
 #[cfg(test)]
 mod log;
 #[cfg(test)]


### PR DESCRIPTION
# Git LFS Support ( #278 ) - Partial Implementation (`git toprepo lfs fetch`)

 
## Overview

 
This PR implements partial Git LFS support for git-toprepo emulated monorepos, specifically the `git toprepo lfs fetch` command.
 
## What Was Implemented
 
### 1. `git toprepo lfs fetch <path>` Command
- **Core functionality**: Fetches LFS objects for specified paths by resolving the correct remote URL based on submodule configuration
- **Path resolution**: 
  - Maps worktree paths to the appropriate repository (top-level or submodule)
  - Uses `.gitmodules` to find the deepest matching submodule for a given path
  - Resolves relative submodule URLs against the top repository's remote URL
  - Validates that submodule URLs are configured in `.gittoprepo.toml`
- **Supported options**: `--dry-run`, `--prune`, `--recent`, `--refetch`, `--exclude`/-X
- **Path handling**:
  - Supports both absolute and relative paths
  - Handles paths with spaces correctly
  - Works from any subdirectory within the worktree
  - Fetches multiple paths sequentially (one `git lfs fetch` call per path)
 
### 2. LFS Filter Warning System
- **Automatic detection**: During `git toprepo fetch`, checks if LFS filters are configured
- **Warning conditions**:
  - Warns if `filter.lfs.smudge` is set to plain `git-lfs` instead of `git-toprepo lfs smudge`
  - Warns if `filter.lfs.process` is set to plain `git-lfs filter-process` instead of going through git-toprepo
- **Rationale**: If LFS filters bypass git-toprepo, they will fetch from the wrong remote in an emulated monorepo context
 
### 3. New Module: `src/lfs.rs` 
Core LFS functionality including:
- `resolve_lfs_fetch_targets()`: Maps paths to repository URLs
- `run_lfs_fetch()`: Executes `git lfs fetch` with the correct remote
- `warn_if_lfs_filters_bypass_toprepo()`: Checks git config for problematic LFS filter settings
- `ensure_git_lfs_available()`: Validates that Git LFS is installed
- `is_lfs_filter_through_toprepo()`: Parses filter commands to detect git-toprepo wrappers
 
### 4. Comprehensive Test Coverage
- **Unit tests** in `src/lfs.rs`:
  - Filter command parsing
  - Deepest submodule path resolution
  - Path normalization edge cases
- **Integration tests** in `tests/integration/lfs.rs` (362 lines):
  - Fetching from top-level repository
  - Fetching from submodules (resolves correct URL)
  - Relative path handling from subdirectories
  - Multiple path fetching
  - Nested submodules (deepest match wins)
  - Spaces in file paths
  - Error handling for missing Git LFS
  - Error handling for unconfigured subrepositories
 
## Caveats and Limitations
 
### Unsupported Options
The following `git lfs fetch` options are explicitly rejected:
- `--all`: Would require fetching from all configured subrepos, complex to implement correctly
- `--stdin`: Not implemented
- `--include`/`-I`: Reserved for internal use (git-toprepo supplies this)
- `--json`: Not implemented

 
## Testing
 
All new code is covered by:
- Unit tests for core logic (filter parsing, path resolution)
- Integration tests using a fake `git-lfs` binary to verify correct command invocation
- Tests cover top-level files, submodule files, nested submodules, error cases
 
Tests only run on Unix due to shell script fixtures.
 

